### PR TITLE
fix: .husky 폴더 내 .gitignore 제거로 commit-msg 훅 정상 작동 처리

### DIFF
--- a/.husky/_/applypatch-msg
+++ b/.husky/_/applypatch-msg
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/h"

--- a/.husky/_/commit-msg
+++ b/.husky/_/commit-msg
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+npx --no -- commitlint --edit "$1"

--- a/.husky/_/h
+++ b/.husky/_/h
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+[ "$HUSKY" = "2" ] && set -x
+n=$(basename "$0")
+s=$(dirname "$(dirname "$0")")/$n
+
+[ ! -f "$s" ] && exit 0
+
+if [ -f "$HOME/.huskyrc" ]; then
+	echo "husky - '~/.huskyrc' is DEPRECATED, please move your code to ~/.config/husky/init.sh"
+fi
+i="${XDG_CONFIG_HOME:-$HOME/.config}/husky/init.sh"
+[ -f "$i" ] && . "$i"
+
+[ "${HUSKY-}" = "0" ] && exit 0
+
+export PATH="node_modules/.bin:$PATH"
+sh -e "$s" "$@"
+c=$?
+
+[ $c != 0 ] && echo "husky - $n script failed (code $c)"
+[ $c = 127 ] && echo "husky - command not found in PATH=$PATH"
+exit $c

--- a/.husky/_/post-applypatch
+++ b/.husky/_/post-applypatch
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/h"

--- a/.husky/_/post-checkout
+++ b/.husky/_/post-checkout
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/h"

--- a/.husky/_/post-commit
+++ b/.husky/_/post-commit
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/h"

--- a/.husky/_/post-merge
+++ b/.husky/_/post-merge
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/h"

--- a/.husky/_/post-rewrite
+++ b/.husky/_/post-rewrite
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/h"

--- a/.husky/_/pre-applypatch
+++ b/.husky/_/pre-applypatch
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/h"

--- a/.husky/_/pre-auto-gc
+++ b/.husky/_/pre-auto-gc
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/h"

--- a/.husky/_/pre-commit
+++ b/.husky/_/pre-commit
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/h"

--- a/.husky/_/pre-merge-commit
+++ b/.husky/_/pre-merge-commit
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/h"

--- a/.husky/_/pre-push
+++ b/.husky/_/pre-push
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/h"

--- a/.husky/_/pre-rebase
+++ b/.husky/_/pre-rebase
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/h"

--- a/.husky/_/prepare-commit-msg
+++ b/.husky/_/prepare-commit-msg
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/h"


### PR DESCRIPTION
## 🧩 이슈  번호 
<!-- 이슈 번호를 작성해주세요 -->

- close #8

## ✅ 작업 사항 
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- .husky 폴더 내 .gitignore 파일로 인해 commit-msg 훅이 Git에 추적되지 않아 commitlint가 동작하지 않았음.     
- 해당 파일을 제거하고 commit-msg 훅을 스테이징하여 문제 해결함.
## 📸 스크린샷 (선택)

## 💬 공유사항

<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
