### PR TITLE
feat: 휴가 관리 페이지 캘린더 시스템 개선

### DIFF
--- a/app/vacation/components/calendar.jsx
+++ b/app/vacation/components/calendar.jsx
@@ -1,62 +1,18 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { format, isSameDay, addDays, startOfDay } from "date-fns";
+import {
+  format,
+  isSameDay,
+  getDay,
+  startOfMonth,
+  endOfMonth,
+  eachDayOfInterval,
+  isToday,
+} from "date-fns";
 import { ko } from "date-fns/locale";
-import { DayPicker, useNavigation } from "react-day-picker"; // ← useNavigation 추가
-import { Card } from "@/components/ui/card";
-import "react-day-picker/dist/style.css";
-
-/** ✅ 타이틀/네비를 하나로 묶은 커스텀 캡션 */
-function CaptionBar({ displayMonth }) {
-  const { previousMonth, nextMonth, goToMonth } = useNavigation();
-
-  return (
-    <div className="flex items-center justify-between px-3 pt-3 pb-2">
-      <button
-        type="button"
-        aria-label="이전 달"
-        disabled={!previousMonth}
-        onClick={() => previousMonth && goToMonth(previousMonth)}
-        className="h-7 w-7 rounded-md text-blue-600 hover:bg-blue-50 disabled:opacity-40 disabled:hover:bg-transparent"
-      >
-        {/* ← 아이콘 */}
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
-          <path
-            d="M15 18l-6-6 6-6"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
-      </button>
-
-      <div className="text-base font-semibold">
-        {format(displayMonth, "M월 yyyy", { locale: ko })}
-      </div>
-
-      <button
-        type="button"
-        aria-label="다음 달"
-        disabled={!nextMonth}
-        onClick={() => nextMonth && goToMonth(nextMonth)}
-        className="h-7 w-7 rounded-md text-blue-600 hover:bg-blue-50 disabled:opacity-40 disabled:hover:bg-transparent"
-      >
-        {/* → 아이콘 */}
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
-          <path
-            d="M9 6l6 6-6 6"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
-      </button>
-    </div>
-  );
-}
+import { Button } from "@/components/ui/button";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 
 export default function Calendar({
   startDate,
@@ -66,6 +22,7 @@ export default function Calendar({
   selectedDates,
   isFilterMode = false,
 }) {
+  const [currentMonth, setCurrentMonth] = useState(new Date());
   const [range, setRange] = useState({
     from: startDate ? new Date(startDate) : null,
     to: endDate ? new Date(endDate) : null,
@@ -79,77 +36,222 @@ export default function Calendar({
     });
   }, [startDate, endDate]);
 
-  // 날짜 범위가 변경될 때 부모 컴포넌트에 알림
-  const handleRangeSelect = (selectedRange) => {
-    setRange(selectedRange);
+  const handleDateClick = (date) => {
+    if (!range.from || (range.from && range.to)) {
+      // 새로운 범위 시작
+      setRange({ from: date, to: null });
+      onStartDateChange(date);
+      onEndDateChange(null);
+    } else {
+      // 범위 완성
+      const from = range.from;
+      const to = date;
 
-    if (selectedRange?.from) {
-      onStartDateChange(selectedRange.from);
-    }
-
-    if (selectedRange?.to) {
-      onEndDateChange(selectedRange.to);
+      if (from > to) {
+        setRange({ from: to, to: from });
+        onStartDateChange(to);
+        onEndDateChange(from);
+      } else {
+        setRange({ from, to });
+        onStartDateChange(from);
+        onEndDateChange(to);
+      }
     }
   };
+
+  const handleMonthChange = (direction) => {
+    setCurrentMonth((prev) => {
+      const newMonth = new Date(prev);
+      if (direction === "next") {
+        newMonth.setMonth(newMonth.getMonth() + 1);
+      } else {
+        newMonth.setMonth(newMonth.getMonth() - 1);
+      }
+      return newMonth;
+    });
+  };
+
+  const getCalendarDays = () => {
+    const start = startOfMonth(currentMonth);
+    const end = endOfMonth(currentMonth);
+    const startDay = getDay(start);
+
+    const days = [];
+
+    // 이전 달의 마지막 날들
+    const prevMonth = new Date(currentMonth);
+    prevMonth.setMonth(prevMonth.getMonth() - 1);
+    const prevMonthEnd = endOfMonth(prevMonth);
+
+    for (let i = startDay - 1; i >= 0; i--) {
+      days.push({
+        date: new Date(prevMonthEnd.getTime() - i * 24 * 60 * 60 * 1000),
+        isCurrentMonth: false,
+      });
+    }
+
+    // 현재 달의 날들
+    const currentMonthDays = eachDayOfInterval({ start, end });
+    days.push(
+      ...currentMonthDays.map((date) => ({
+        date,
+        isCurrentMonth: true,
+      }))
+    );
+
+    // 다음 달의 첫 날들 (42개 셀을 채우기 위해)
+    const remainingDays = 42 - days.length;
+    for (let i = 1; i <= remainingDays; i++) {
+      const nextMonth = new Date(currentMonth);
+      nextMonth.setMonth(nextMonth.getMonth() + 1);
+      nextMonth.setDate(i);
+      days.push({
+        date: nextMonth,
+        isCurrentMonth: false,
+      });
+    }
+
+    return days;
+  };
+
+  const isInRange = (date) => {
+    if (!range.from) return false;
+    if (!range.to) return isSameDay(date, range.from);
+    return date >= range.from && date <= range.to;
+  };
+
+  const isRangeStart = (date) => {
+    return range.from && isSameDay(date, range.from);
+  };
+
+  const isRangeEnd = (date) => {
+    return range.to && isSameDay(date, range.to);
+  };
+
+  const weekdays = ["일", "월", "화", "수", "목", "금", "토"];
 
   return (
     <div className={isFilterMode ? "mb-0" : "mb-4"}>
       {!isFilterMode && (
-        <label className="block text-sm font-medium text-gray-700 mb-2">
+        <label className="block text-sm font-medium text-foreground mb-2">
           날짜 선택
         </label>
       )}
-      <Card
-        className={`${
-          isFilterMode ? "p-2" : "p-3"
-        } bg-white/60 backdrop-blur-sm border-gray-200/50`}
-      >
-        <DayPicker
-          mode="range"
-          defaultMonth={new Date()} // 오늘 날짜를 초기 표시
-          selected={range}
-          onSelect={handleRangeSelect}
-          locale={ko}
-          /** 커스텀 캡션 사용: 타이틀/네비 묶음 */
-          components={{ Caption: CaptionBar }}
-          className="custom-day-picker"
-          classNames={{
-            months:
-              "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
-            /** 캡션을 따로 절대배치하지 않고, 기본 흐름에서 위쪽에 배치 */
-            month: "space-y-3", // 필요하면 "pt-1" 등으로 미세 조정
 
-            // caption/nav 관련 기존 절대배치/좌표는 제거 (커스텀 캡션이 대체)
-            // caption: "flex justify-between items-center pt-1 relative w-full",
-            // caption_label: "font-semibold text-sm",
-            // nav: "flex items-center gap-1",
-            // nav_button_previous: "absolute left-0",
-            // nav_button_next: "absolute right-0",
+      {/* Desktop Calendar */}
+      <div className="space-y-3">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => handleMonthChange("prev")}
+            className="h-8 w-8 p-0 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
 
-            table: "w-full border-collapse space-y-1",
-            head_row: "flex",
-            head_cell: `text-gray-500 rounded-md w-7 font-normal ${
-              isFilterMode ? "text-[0.6rem]" : "text-[0.8rem]"
-            }`,
-            row: "flex w-full mt-1",
-            cell: "text-center text-sm p-0 relative [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
-            day: `p-0 font-normal aria-selected:opacity-100 hover:bg-gray-100 rounded-md ${
-              isFilterMode ? "h-5 w-5 text-xs" : "h-8 w-8 text-sm"
-            }`,
-            day_selected:
-              "bg-blue-500 text-white hover:bg-blue-600 focus:bg-blue-500",
-            day_today: "bg-gray-100 text-gray-900",
-            day_outside: "text-gray-400 opacity-50",
-            day_disabled: "text-gray-400 opacity-50",
-            day_range_middle:
-              "aria-selected:bg-blue-100 aria-selected:text-blue-900",
-            day_hidden: "invisible",
-          }}
-          styles={{
-            day: { margin: 0 },
-          }}
-        />
-      </Card>
+          <h3 className="text-sm font-semibold text-foreground">
+            {format(currentMonth, "yyyy년 M월", { locale: ko })}
+          </h3>
+
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => handleMonthChange("next")}
+            className="h-8 w-8 p-0 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+
+        {/* Weekdays */}
+        <div className="grid grid-cols-7 gap-1">
+          {weekdays.map((day, index) => (
+            <div
+              key={day}
+              className={`text-xs font-medium h-8 w-8 flex items-center justify-center ${
+                index === 0
+                  ? "text-red-500"
+                  : index === 6
+                  ? "text-blue-500"
+                  : "text-muted-foreground"
+              }`}
+            >
+              {day}
+            </div>
+          ))}
+        </div>
+
+        {/* Calendar Grid */}
+        <div className="grid grid-cols-7 gap-1">
+          {getCalendarDays().map((day, index) => {
+            const isTodayDate = isToday(day.date);
+            const inRange = isInRange(day.date);
+            const isStart = isRangeStart(day.date);
+            const isEnd = isRangeEnd(day.date);
+            const dayOfWeek = getDay(day.date);
+
+            return (
+              <button
+                key={index}
+                onClick={() => handleDateClick(day.date)}
+                className={`
+                  h-8 w-8 text-xs font-medium rounded-md transition-all duration-200 flex items-center justify-center
+                  ${
+                    !day.isCurrentMonth
+                      ? "text-muted-foreground/50"
+                      : "text-foreground"
+                  }
+                  ${isTodayDate ? "ring-2 ring-green-500 ring-offset-1" : ""}
+                  ${inRange ? "bg-primary text-primary-foreground" : ""}
+                  ${
+                    isStart
+                      ? "bg-primary text-primary-foreground font-bold"
+                      : ""
+                  }
+                  ${isEnd ? "bg-primary text-primary-foreground font-bold" : ""}
+                  ${
+                    !day.isCurrentMonth
+                      ? "hover:bg-accent/50"
+                      : "hover:bg-accent"
+                  }
+                  ${inRange && !isStart && !isEnd ? "bg-primary/20" : ""}
+                  ${dayOfWeek === 0 ? "text-red-500" : ""}
+                  ${dayOfWeek === 6 ? "text-blue-500" : ""}
+                `}
+              >
+                {format(day.date, "d")}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-between items-center pt-3 border-t border-border">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              setRange({ from: null, to: null });
+              onStartDateChange(null);
+              onEndDateChange(null);
+            }}
+            className="text-xs text-muted-foreground hover:text-foreground"
+          >
+            초기화
+          </Button>
+
+          <div className="text-xs text-muted-foreground">
+            {range.from && range.to && (
+              <span>
+                {format(range.from, "MMM dd", { locale: ko })} -{" "}
+                {format(range.to, "MMM dd", { locale: ko })}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/app/vacation/page.jsx
+++ b/app/vacation/page.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import React from "react";
 import {
   Bell,
@@ -45,6 +45,7 @@ export default function VacationPage() {
   const [endDate, setEndDate] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
   const [isCalendarOpen, setIsCalendarOpen] = useState(false);
+  const calendarRef = useRef(null);
 
   // 1년을 3개월씩 나눈 기간들
   const periods = [
@@ -328,6 +329,18 @@ export default function VacationPage() {
     setCurrentPage(1);
   }, [startDate, endDate, selectedPeriod]);
 
+  // 외부 클릭 시 캘린더 닫기
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (calendarRef.current && !calendarRef.current.contains(event.target)) {
+        setIsCalendarOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
   const vacationStats = [
     {
       title: "기본 연차",
@@ -414,67 +427,37 @@ export default function VacationPage() {
         <div className="flex items-center justify-between mb-6">
           <h3 className={`${typography.h2} text-gray-800`}>휴가 기록</h3>
           <div className="flex items-center gap-4">
-            {/* 날짜 필터링 버튼 */}
-            <div className="relative">
+            {/* 날짜 필터링 - MUI Desktop variant */}
+            <div className="relative" ref={calendarRef}>
               <div className="flex items-center gap-2">
                 <Button
                   variant="outline"
                   onClick={() => setIsCalendarOpen(!isCalendarOpen)}
-                  className="px-4 py-2 bg-white/60 backdrop-blur-sm border-gray-200/50 rounded-xl text-sm flex items-center gap-2"
+                  className="px-4 py-2 bg-card backdrop-blur-sm border-border rounded-lg text-sm flex items-center gap-2 text-card-foreground hover:bg-accent hover:text-accent-foreground"
                 >
                   <Calendar className="w-4 h-4" />
                   {startDate && endDate
                     ? `${startDate} ~ ${endDate}`
-                    : "날짜 선택"}
+                    : "날짜 범위 선택"}
                 </Button>
-                {startDate && endDate && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => {
-                      setStartDate("");
-                      setEndDate("");
-                      setIsCalendarOpen(false);
-                    }}
-                    className="px-2 py-1 text-xs text-gray-500 hover:text-red-500 hover:bg-red-50"
-                    title="날짜 범위 초기화"
-                  >
-                    초기화
-                  </Button>
-                )}
               </div>
 
-              {/* Calendar 모달 */}
+              {/* Desktop Calendar Popover */}
               {isCalendarOpen && (
-                <div className="absolute top-full right-0 mt-2 z-50">
-                  <div className="bg-white rounded-lg shadow-xl border border-gray-200 p-4">
+                <div className="absolute top-full left-0 mt-2 z-50">
+                  <div className="bg-popover backdrop-blur-sm border border-border rounded-xl shadow-2xl p-4 min-w-[320px]">
                     <div className="flex items-center justify-between mb-3">
-                      <h4 className="font-semibold text-gray-800">
+                      <h4 className="text-sm font-semibold text-popover-foreground">
                         날짜 범위 선택
                       </h4>
-                      <div className="flex items-center gap-2">
-                        {(startDate || endDate) && (
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => {
-                              setStartDate("");
-                              setEndDate("");
-                            }}
-                            className="px-2 py-1 text-xs text-gray-500 hover:text-red-500 hover:bg-red-50"
-                          >
-                            초기화
-                          </Button>
-                        )}
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          onClick={() => setIsCalendarOpen(false)}
-                          className="w-6 h-6"
-                        >
-                          <X className="w-4 h-4" />
-                        </Button>
-                      </div>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => setIsCalendarOpen(false)}
+                        className="w-6 h-6 text-muted-foreground hover:text-foreground hover:bg-accent"
+                      >
+                        <X className="w-4 h-4" />
+                      </Button>
                     </div>
                     <CalendarComponent
                       startDate={startDate}

--- a/app/vacation/vacationmodal.jsx
+++ b/app/vacation/vacationmodal.jsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { format } from "date-fns";
+import { ko } from "date-fns/locale";
 import { X, Clock, FileText } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -51,12 +52,11 @@ export default function VacationModal({
   ];
 
   const handleStartDateChange = (newStartDate) => {
-    console.log("시작일 선택:", newStartDate); // 디버깅용
     setStartDate(newStartDate);
 
     // 시작일만 선택된 경우에도 해당 날짜를 selectedDates에 추가
     if (newStartDate && !endDate) {
-      setSelectedDates([new Date(newStartDate)]);
+      setSelectedDates([newStartDate]);
     } else if (newStartDate && endDate) {
       updateSelectedDates(newStartDate, endDate);
     } else {
@@ -65,12 +65,11 @@ export default function VacationModal({
   };
 
   const handleEndDateChange = (newEndDate) => {
-    console.log("종료일 선택:", newEndDate); // 디버깅용
     setEndDate(newEndDate);
 
     // 종료일만 선택된 경우에도 해당 날짜를 selectedDates에 추가
     if (newEndDate && !startDate) {
-      setSelectedDates([new Date(newEndDate)]);
+      setSelectedDates([newEndDate]);
     } else if (newEndDate && startDate) {
       updateSelectedDates(startDate, newEndDate);
     } else {
@@ -79,17 +78,15 @@ export default function VacationModal({
   };
 
   const updateSelectedDates = (start, end) => {
-    console.log("날짜 업데이트:", start, end); // 디버깅용
-
     if (start && end) {
-      const startDate = new Date(start);
-      const endDate = new Date(end);
+      const startDate = start instanceof Date ? start : new Date(start);
+      const endDate = end instanceof Date ? end : new Date(end);
       const dates = [];
       const current = new Date(startDate);
 
       // 시작일과 종료일이 같은 경우
       if (startDate.getTime() === endDate.getTime()) {
-        dates.push(new Date(startDate));
+        dates.push(startDate);
       } else {
         // 시작일부터 종료일까지 모든 날짜 추가
         while (current <= endDate) {
@@ -97,14 +94,13 @@ export default function VacationModal({
           current.setDate(current.getDate() + 1);
         }
       }
-      console.log("생성된 날짜 배열:", dates); // 디버깅용
       setSelectedDates(dates);
     } else if (start) {
       // 시작일만 있는 경우
-      setSelectedDates([new Date(start)]);
+      setSelectedDates([start instanceof Date ? start : new Date(start)]);
     } else if (end) {
       // 종료일만 있는 경우
-      setSelectedDates([new Date(end)]);
+      setSelectedDates([end instanceof Date ? end : new Date(end)]);
     } else {
       setSelectedDates([]);
     }
@@ -194,59 +190,87 @@ export default function VacationModal({
             selectedDates={selectedDates}
           />
 
-          {/* Time Inputs */}
-          <div className="grid grid-cols-2 gap-4 mb-4">
-            <div className="relative">
-              <label className="block text-sm font-medium text-gray-700 mb-2">
-                휴가 시작 시간
-              </label>
+          {/* Date Range Info - 범위 선택 시에만 표시 */}
+          {startDate &&
+            endDate &&
+            startDate.getTime() !== endDate.getTime() && (
+              <div className="mb-4 p-3 bg-blue-50/50 border border-blue-200/50 rounded-xl">
+                <div className="flex items-center justify-between">
+                  <div className="text-sm text-blue-700">
+                    <span className="font-medium">선택된 기간:</span>{" "}
+                    {format(new Date(startDate), "yyyy년 M월 d일", {
+                      locale: ko,
+                    })}{" "}
+                    ~{" "}
+                    {format(new Date(endDate), "yyyy년 M월 d일", {
+                      locale: ko,
+                    })}
+                  </div>
+                  <div className="text-sm font-medium text-blue-700">
+                    {selectedDates.length}일
+                  </div>
+                </div>
+              </div>
+            )}
+
+          {/* Time Inputs - 단일 날짜 선택 시에만 표시 */}
+          {((startDate && !endDate) ||
+            (startDate &&
+              endDate &&
+              startDate.getTime() === endDate.getTime())) && (
+            <div className="grid grid-cols-2 gap-4 mb-4">
               <div className="relative">
-                <Clock className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400" />
-                <Input
-                  type="text"
-                  value={startTime}
-                  readOnly
-                  onClick={() => {
-                    setShowStartTimeDropdown(!showStartTimeDropdown);
-                    setShowEndTimeDropdown(false);
-                  }}
-                  className="pl-10 bg-white/60 backdrop-blur-sm border-gray-200/50 rounded-xl cursor-pointer"
-                />
-                {showStartTimeDropdown && (
-                  <SelectTime
-                    onTimeSelect={handleStartTimeSelect}
-                    onClose={() => setShowStartTimeDropdown(false)}
-                    isDropdown={true}
+                <label className="block text-sm font-medium text-gray-700 mb-2">
+                  휴가 시작 시간
+                </label>
+                <div className="relative">
+                  <Clock className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400" />
+                  <Input
+                    type="text"
+                    value={startTime}
+                    readOnly
+                    onClick={() => {
+                      setShowStartTimeDropdown(!showStartTimeDropdown);
+                      setShowEndTimeDropdown(false);
+                    }}
+                    className="pl-10 bg-white/60 backdrop-blur-sm border-gray-200/50 rounded-xl cursor-pointer"
                   />
-                )}
+                  {showStartTimeDropdown && (
+                    <SelectTime
+                      onTimeSelect={handleStartTimeSelect}
+                      onClose={() => setShowStartTimeDropdown(false)}
+                      isDropdown={true}
+                    />
+                  )}
+                </div>
+              </div>
+              <div className="relative">
+                <label className="block text-sm font-medium text-gray-700 mb-2">
+                  휴가 종료 시간
+                </label>
+                <div className="relative">
+                  <Clock className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400" />
+                  <Input
+                    type="text"
+                    value={endTime}
+                    readOnly
+                    onClick={() => {
+                      setShowEndTimeDropdown(!showEndTimeDropdown);
+                      setShowStartTimeDropdown(false);
+                    }}
+                    className="pl-10 bg-white/60 backdrop-blur-sm border-gray-200/50 rounded-xl cursor-pointer"
+                  />
+                  {showEndTimeDropdown && (
+                    <SelectTime
+                      onTimeSelect={handleEndTimeSelect}
+                      onClose={() => setShowEndTimeDropdown(false)}
+                      isDropdown={true}
+                    />
+                  )}
+                </div>
               </div>
             </div>
-            <div className="relative">
-              <label className="block text-sm font-medium text-gray-700 mb-2">
-                휴가 종료 시간
-              </label>
-              <div className="relative">
-                <Clock className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400" />
-                <Input
-                  type="text"
-                  value={endTime}
-                  readOnly
-                  onClick={() => {
-                    setShowEndTimeDropdown(!showEndTimeDropdown);
-                    setShowStartTimeDropdown(false);
-                  }}
-                  className="pl-10 bg-white/60 backdrop-blur-sm border-gray-200/50 rounded-xl cursor-pointer"
-                />
-                {showEndTimeDropdown && (
-                  <SelectTime
-                    onTimeSelect={handleEndTimeSelect}
-                    onClose={() => setShowEndTimeDropdown(false)}
-                    isDropdown={true}
-                  />
-                )}
-              </div>
-            </div>
-          </div>
+          )}
 
           {/* Reason Textarea */}
           <div className="mb-4">


### PR DESCRIPTION
## 🧩 이슈  번호 
<!-- 이슈 번호를 작성해주세요 -->

- close #60 

## ✅ 작업 사항 
- MUI 스타일의 커스텀 캘린더 컴포넌트 구현
- 날짜 선택 상태에 따른 동적 UI 변경 (시간 입력/범위 정보)
- globals.css 테마 시스템 적용 및 다크모드 지원
- 캘린더 정렬 문제 해결 및 요일별 색상 적용
- 휴가 신청 모달의 사용자 경험 개선

## 📸 스크린샷 (선택)
### 날짜 범위 선택 달력 UI
<img width="500" height="717" alt="image" src="https://github.com/user-attachments/assets/dfe114bc-3836-498a-ab1f-f093a1828903" />

### 휴가 신청 모달창 UI
<img width="788" height="1114" alt="image" src="https://github.com/user-attachments/assets/7e50842f-9428-448f-b06b-0eb1cca63162" />

### 하루 선택했을 때
<img width="785" height="1120" alt="image" src="https://github.com/user-attachments/assets/bbfbb013-8c2c-44c8-ab3a-44def71bcbf9" />

### 범위 선택했을 때
<img width="804" height="1130" alt="image" src="https://github.com/user-attachments/assets/52b25c15-f271-4504-83ce-b2e5b054d6b1" />

## 💬 공유사항

<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
