### PR TITLE
API 클라이언트 아키텍처

### DIFF
--- a/lib/services/README.md
+++ b/lib/services/README.md
@@ -1,0 +1,93 @@
+# Services Structure
+
+MSA(Microservices Architecture) 환경을 위한 서비스별 API 클라이언트 구조입니다.
+
+## 폴더 구조
+
+```
+lib/services/
+├── common/                    # 공통 타입 및 유틸리티
+│   ├── types.ts              # 공통 API 응답 타입 (ApiResult, PageResult 등)
+│   ├── api-client.ts         # 공통 HTTP 클라이언트 설정
+│   └── index.ts              # 공통 exports
+├── approval/                  # 승인 서비스
+│   ├── types.ts              # 승인 서비스 전용 타입
+│   ├── api.ts                # 승인 서비스 API 함수들
+│   └── index.ts              # 승인 서비스 exports
+├── user/                      # 사용자 서비스 (예시)
+│   ├── types.ts              # 사용자 서비스 전용 타입
+│   ├── api.ts                # 사용자 서비스 API 함수들
+│   └── index.ts              # 사용자 서비스 exports
+├── notification/              # 알림 서비스 (예시)
+│   ├── types.ts              # 알림 서비스 전용 타입
+│   ├── api.ts                # 알림 서비스 API 함수들
+│   └── index.ts              # 알림 서비스 exports
+└── index.ts                   # 전체 서비스 exports
+```
+
+## 사용 방법
+
+### 1. 특정 서비스만 임포트
+```typescript
+import { approvalApi, DocumentStatus } from '@/lib/services/approval'
+import { userApi, UserRole } from '@/lib/services/user'
+```
+
+### 2. 공통 타입 사용
+```typescript
+import { ApiResult, PageResult } from '@/lib/services/common'
+```
+
+### 3. 모든 서비스 임포트
+```typescript
+import { approvalApi, userApi, notificationApi } from '@/lib/services'
+```
+
+## 새로운 서비스 추가하기
+
+1. `lib/services/` 하위에 서비스 이름으로 폴더 생성
+2. 해당 폴더에 `types.ts`, `api.ts`, `index.ts` 파일 생성
+3. `lib/services/index.ts`에 새 서비스 export 추가
+
+### 예시: File Service 추가
+
+```typescript
+// lib/services/file/types.ts
+export interface FileUploadResponse {
+  fileId: string
+  fileName: string
+  fileUrl: string
+  fileSize: number
+}
+
+// lib/services/file/api.ts
+import apiClient from '../common/api-client'
+import { FileUploadResponse } from './types'
+
+export const fileApi = {
+  uploadFile: async (file: File): Promise<FileUploadResponse> => {
+    const formData = new FormData()
+    formData.append('file', file)
+    const response = await apiClient.post('/api/files/upload', formData, {
+      headers: { 'Content-Type': 'multipart/form-data' }
+    })
+    return response.data.data
+  }
+}
+
+// lib/services/file/index.ts
+export * from './types'
+export * from './api'
+export { fileApi as default } from './api'
+
+// lib/services/index.ts에 추가
+export * from './file'
+```
+
+## 장점
+
+1. **서비스별 관심사 분리**: 각 MSA 서비스의 타입과 API가 독립적으로 관리됨
+2. **확장성**: 새로운 서비스 추가가 용이함
+3. **타입 안전성**: 서비스별 타입 정의로 컴파일 타임 에러 방지
+4. **트리 쉐이킹**: 필요한 서비스만 번들에 포함됨
+5. **유지보수성**: 서비스별로 독립적인 수정 가능

--- a/lib/services/approval/api.ts
+++ b/lib/services/approval/api.ts
@@ -1,0 +1,201 @@
+import apiClient from '../common/api-client'
+import {
+  ApiResultCategoryResponse,
+  ApiResultListCategoryResponse,
+  ApiResultTemplateResponse,
+  ApiResultListTemplateSummaryResponse,
+  ApiResultListTemplatesByCategoryResponse,
+  ApiResultDocumentResponse,
+  ApiResultPageDocumentSummaryResponse,
+  ApiResultDocumentCommentResponse,
+  ApiResultListDocumentCommentResponse,
+  ApiResultVoid,
+  CategoryResponse,
+  CreateCategoryRequest,
+  UpdateCategoryRequest,
+  TemplateResponse,
+  TemplateSummaryResponse,
+  TemplatesByCategoryResponse,
+  CreateTemplateRequest,
+  UpdateTemplateRequest,
+  DocumentResponse,
+  DocumentSummaryResponse,
+  CreateDocumentRequest,
+  UpdateDocumentRequest,
+  ApprovalActionRequest,
+  DocumentCommentResponse,
+  CreateCommentRequest,
+  GetDocumentsParams,
+  GetTemplatesParams,
+} from './types'
+import { PageResult } from '../common/types'
+
+// 카테고리 관련 API
+export const categoryApi = {
+  // 카테고리 목록 조회
+  getCategories: async (): Promise<CategoryResponse[]> => {
+    const response = await apiClient.get<ApiResultListCategoryResponse>('/api/approval/categories')
+    return response.data.data
+  },
+
+  // 카테고리 상세 조회
+  getCategoryById: async (id: number): Promise<CategoryResponse> => {
+    const response = await apiClient.get<ApiResultCategoryResponse>(`/api/approval/categories/${id}`)
+    return response.data.data
+  },
+
+  // 카테고리 생성
+  createCategory: async (request: CreateCategoryRequest): Promise<CategoryResponse> => {
+    const response = await apiClient.post<ApiResultCategoryResponse>('/api/approval/categories', request)
+    return response.data.data
+  },
+
+  // 카테고리 수정
+  updateCategory: async (id: number, request: UpdateCategoryRequest): Promise<CategoryResponse> => {
+    const response = await apiClient.put<ApiResultCategoryResponse>(`/api/approval/categories/${id}`, request)
+    return response.data.data
+  },
+
+  // 카테고리 삭제
+  deleteCategory: async (id: number): Promise<void> => {
+    await apiClient.delete<ApiResultVoid>(`/api/approval/categories/${id}`)
+  },
+}
+
+// 템플릿 관련 API
+export const templateApi = {
+  // 템플릿 목록 조회
+  getTemplates: async (params?: GetTemplatesParams): Promise<TemplateSummaryResponse[]> => {
+    const queryParams = params?.categoryId ? { categoryId: params.categoryId } : {}
+    const response = await apiClient.get<ApiResultListTemplateSummaryResponse>('/api/approval/templates', {
+      params: queryParams
+    })
+    return response.data.data
+  },
+
+  // 카테고리별 템플릿 조회
+  getTemplatesByCategory: async (): Promise<TemplatesByCategoryResponse[]> => {
+    const response = await apiClient.get<ApiResultListTemplatesByCategoryResponse>('/api/approval/templates/by-category')
+    return response.data.data
+  },
+
+  // 템플릿 상세 조회
+  getTemplateById: async (id: number): Promise<TemplateResponse> => {
+    const response = await apiClient.get<ApiResultTemplateResponse>(`/api/approval/templates/${id}`)
+    return response.data.data
+  },
+
+  // 템플릿 생성
+  createTemplate: async (request: CreateTemplateRequest): Promise<TemplateResponse> => {
+    const response = await apiClient.post<ApiResultTemplateResponse>('/api/approval/templates', request)
+    return response.data.data
+  },
+
+  // 템플릿 수정
+  updateTemplate: async (id: number, request: UpdateTemplateRequest): Promise<TemplateResponse> => {
+    const response = await apiClient.put<ApiResultTemplateResponse>(`/api/approval/templates/${id}`, request)
+    return response.data.data
+  },
+
+  // 템플릿 삭제
+  deleteTemplate: async (id: number): Promise<void> => {
+    await apiClient.delete<ApiResultVoid>(`/api/approval/templates/${id}`)
+  },
+
+  // 템플릿 공개/숨김 설정
+  updateTemplateVisibility: async (id: number, isHidden: boolean): Promise<void> => {
+    await apiClient.put<ApiResultVoid>(`/api/approval/templates/${id}/visibility`, null, {
+      params: { isHidden }
+    })
+  },
+}
+
+// 문서 관련 API
+export const documentApi = {
+  // 문서 목록 조회
+  getDocuments: async (params: GetDocumentsParams): Promise<PageResult<DocumentSummaryResponse>> => {
+    const queryParams: any = {
+      page: params.pageable.page,
+      size: params.pageable.size,
+    }
+    
+    if (params.pageable.sort) {
+      queryParams.sort = params.pageable.sort
+    }
+    if (params.status && params.status.length > 0) {
+      queryParams.status = params.status
+    }
+    if (params.search) {
+      queryParams.search = params.search
+    }
+    if (params.startDate) {
+      queryParams.startDate = params.startDate
+    }
+    if (params.endDate) {
+      queryParams.endDate = params.endDate
+    }
+
+    const response = await apiClient.get<ApiResultPageDocumentSummaryResponse>('/api/approval/documents', {
+      params: queryParams
+    })
+    return response.data.data
+  },
+
+  // 문서 상세 조회
+  getDocumentById: async (id: number): Promise<DocumentResponse> => {
+    const response = await apiClient.get<ApiResultDocumentResponse>(`/api/approval/documents/${id}`)
+    return response.data.data
+  },
+
+  // 문서 작성
+  createDocument: async (request: CreateDocumentRequest): Promise<DocumentResponse> => {
+    const response = await apiClient.post<ApiResultDocumentResponse>('/api/approval/documents', request)
+    return response.data.data
+  },
+
+  // 문서 수정
+  updateDocument: async (id: number, request: UpdateDocumentRequest): Promise<DocumentResponse> => {
+    const response = await apiClient.put<ApiResultDocumentResponse>(`/api/approval/documents/${id}`, request)
+    return response.data.data
+  },
+
+  // 문서 제출
+  submitDocument: async (id: number): Promise<void> => {
+    await apiClient.post<ApiResultVoid>(`/api/approval/documents/${id}/submit`)
+  },
+
+  // 문서 승인
+  approveDocument: async (id: number, request?: ApprovalActionRequest): Promise<void> => {
+    await apiClient.post<ApiResultVoid>(`/api/approval/documents/${id}/approve`, request || {})
+  },
+
+  // 문서 반려
+  rejectDocument: async (id: number, request?: ApprovalActionRequest): Promise<void> => {
+    await apiClient.post<ApiResultVoid>(`/api/approval/documents/${id}/reject`, request || {})
+  },
+}
+
+// 댓글 관련 API
+export const commentApi = {
+  // 문서 댓글 목록 조회
+  getComments: async (documentId: number): Promise<DocumentCommentResponse[]> => {
+    const response = await apiClient.get<ApiResultListDocumentCommentResponse>(`/api/approval/documents/${documentId}/comments`)
+    return response.data.data
+  },
+
+  // 문서 댓글 작성
+  createComment: async (documentId: number, request: CreateCommentRequest): Promise<DocumentCommentResponse> => {
+    const response = await apiClient.post<ApiResultDocumentCommentResponse>(`/api/approval/documents/${documentId}/comments`, request)
+    return response.data.data
+  },
+}
+
+// 모든 API를 하나의 객체로 내보내기
+export const approvalApi = {
+  category: categoryApi,
+  template: templateApi,
+  document: documentApi,
+  comment: commentApi,
+}
+
+export default approvalApi

--- a/lib/services/approval/index.ts
+++ b/lib/services/approval/index.ts
@@ -1,0 +1,4 @@
+// 승인 서비스 관련 모든 exports를 한 곳에서 관리
+export * from './types'
+export * from './api'
+export { default as approvalApi } from './api'

--- a/lib/services/approval/types.ts
+++ b/lib/services/approval/types.ts
@@ -1,0 +1,312 @@
+import { ApiResult, PageResult, Pageable } from '../common/types'
+
+// 승인 서비스 특화 열거형
+export enum DocumentStatus {
+  DRAFT = 'DRAFT',
+  PENDING = 'PENDING',
+  IN_PROGRESS = 'IN_PROGRESS',
+  APPROVED = 'APPROVED',
+  REJECTED = 'REJECTED'
+}
+
+export enum TargetType {
+  USER = 'USER',
+  ORGANIZATION = 'ORGANIZATION',
+  N_LEVEL_MANAGER = 'N_LEVEL_MANAGER'
+}
+
+export enum FieldType {
+  TEXT = 'TEXT',
+  NUMBER = 'NUMBER',
+  MONEY = 'MONEY',
+  DATE = 'DATE',
+  SELECT = 'SELECT',
+  MULTISELECT = 'MULTISELECT'
+}
+
+export enum UserRole {
+  AUTHOR = 'AUTHOR',
+  APPROVER = 'APPROVER',
+  REFERENCE = 'REFERENCE',
+  VIEWER = 'VIEWER'
+}
+
+export enum ActivityType {
+  CREATE = 'CREATE',
+  UPDATE = 'UPDATE',
+  SUBMIT = 'SUBMIT',
+  APPROVE = 'APPROVE',
+  REJECT = 'REJECT',
+  MODIFY_APPROVAL = 'MODIFY_APPROVAL',
+  COMMENT = 'COMMENT'
+}
+
+// 카테고리 관련 타입
+export interface CategoryResponse {
+  id: number
+  name: string
+  description?: string
+  sortOrder: number
+  createdAt: string
+  updatedAt: string
+}
+
+export interface CreateCategoryRequest {
+  name: string
+  description?: string
+  sortOrder: number
+}
+
+export interface UpdateCategoryRequest {
+  name: string
+  description?: string
+  sortOrder: number
+}
+
+// 템플릿 관련 타입
+export interface TemplateFieldResponse {
+  id: number
+  name: string
+  fieldType: FieldType
+  required: boolean
+  fieldOrder: number
+  options?: string
+}
+
+export interface TemplateFieldRequest {
+  name: string
+  fieldType: FieldType
+  required: boolean
+  fieldOrder: number
+  options?: string
+}
+
+export interface ApprovalTargetResponse {
+  id: number
+  targetType: TargetType
+  userId?: number
+  organizationId?: number
+  managerLevel?: number
+  isReference: boolean
+  isApproved?: boolean
+  approvedBy?: number
+  approvedAt?: string
+}
+
+export interface ApprovalTargetRequest {
+  targetType: TargetType
+  userId?: number
+  organizationId?: number
+  managerLevel?: number
+  isReference: boolean
+}
+
+export interface ApprovalStageResponse {
+  id: number
+  stageOrder: number
+  stageName: string
+  isCompleted: boolean
+  completedAt?: string
+  approvalTargets: ApprovalTargetResponse[]
+}
+
+export interface ApprovalStageRequest {
+  stageOrder: number
+  stageName: string
+  approvalTargets: ApprovalTargetRequest[]
+}
+
+export interface AttachmentInfoResponse {
+  fileId: string
+  fileName: string
+  fileSize: number
+  contentType: string
+}
+
+export interface TemplateResponse {
+  id: number
+  title: string
+  icon?: string
+  description?: string
+  bodyTemplate?: string
+  useBody: boolean
+  useAttachment: boolean
+  allowTargetChange: boolean
+  isHidden: boolean
+  referenceFiles: AttachmentInfoResponse[]
+  category: CategoryResponse
+  fields: TemplateFieldResponse[]
+  approvalStages: ApprovalStageResponse[]
+  referenceTargets: ApprovalTargetResponse[]
+  createdAt: string
+  updatedAt: string
+}
+
+export interface TemplateSummaryResponse {
+  id: number
+  title: string
+  icon?: string
+  description?: string
+  useBody: boolean
+  useAttachment: boolean
+  allowTargetChange: boolean
+  isHidden: boolean
+  category: CategoryResponse
+  createdAt: string
+  updatedAt: string
+}
+
+export interface TemplatesByCategoryResponse {
+  categoryId: number
+  categoryName: string
+  templates: TemplateSummaryResponse[]
+}
+
+export interface CreateTemplateRequest {
+  title: string
+  icon?: string
+  description?: string
+  bodyTemplate?: string
+  useBody: boolean
+  useAttachment: boolean
+  allowTargetChange: boolean
+  referenceFiles?: string[]
+  categoryId: number
+  fields?: TemplateFieldRequest[]
+  approvalStages?: ApprovalStageRequest[]
+  referenceTargets?: ApprovalTargetRequest[]
+}
+
+export interface UpdateTemplateRequest {
+  title: string
+  icon?: string
+  description?: string
+  bodyTemplate?: string
+  useBody: boolean
+  useAttachment: boolean
+  allowTargetChange: boolean
+  referenceFiles?: string[]
+  categoryId: number
+  fields?: TemplateFieldRequest[]
+  approvalStages?: ApprovalStageRequest[]
+  referenceTargets?: ApprovalTargetRequest[]
+}
+
+// 문서 관련 타입
+export interface DocumentFieldValueResponse {
+  id: number
+  fieldName: string
+  fieldValue?: string
+  templateField: TemplateFieldResponse
+}
+
+export interface DocumentFieldValueRequest {
+  fieldName: string
+  fieldValue?: string
+  templateFieldId?: number
+}
+
+export interface DocumentActivityResponse {
+  id: number
+  activityType: ActivityType
+  userId: number
+  description?: string
+  reason?: string
+  createdAt: string
+}
+
+export interface DocumentCommentResponse {
+  id: number
+  content: string
+  authorId: number
+  createdAt: string
+  updatedAt: string
+}
+
+export interface DocumentResponse {
+  id: number
+  title: string
+  content?: string
+  status: DocumentStatus
+  authorId: number
+  currentStage?: number
+  template: TemplateResponse
+  fieldValues: DocumentFieldValueResponse[]
+  approvalStages: ApprovalStageResponse[]
+  referenceTargets: ApprovalTargetResponse[]
+  activities: DocumentActivityResponse[]
+  comments: DocumentCommentResponse[]
+  attachments: AttachmentInfoResponse[]
+  createdAt: string
+  updatedAt: string
+  submittedAt?: string
+  approvedAt?: string
+}
+
+export interface DocumentSummaryResponse {
+  id: number
+  title: string
+  content?: string
+  status: DocumentStatus
+  authorId: number
+  templateTitle: string
+  currentStage?: number
+  totalStages: number
+  userRole: UserRole
+  createdAt: string
+  submittedAt?: string
+  approvedAt?: string
+}
+
+export interface CreateDocumentRequest {
+  templateId: number
+  title: string
+  content?: string
+  fieldValues?: DocumentFieldValueRequest[]
+  approvalStages?: ApprovalStageRequest[]
+  referenceTargets?: ApprovalTargetRequest[]
+  attachments?: string[]
+}
+
+export interface UpdateDocumentRequest {
+  title: string
+  content?: string
+  fieldValues?: DocumentFieldValueRequest[]
+  approvalStages?: ApprovalStageRequest[]
+  referenceTargets?: ApprovalTargetRequest[]
+  attachments?: string[]
+}
+
+export interface ApprovalActionRequest {
+  reason?: string
+}
+
+// 댓글 관련 타입
+export interface CreateCommentRequest {
+  content: string
+}
+
+// API 요청 파라미터 타입들
+export interface GetDocumentsParams {
+  status?: DocumentStatus[]
+  search?: string
+  startDate?: string
+  endDate?: string
+  pageable: Pageable
+}
+
+export interface GetTemplatesParams {
+  categoryId?: number
+}
+
+// API 응답 타입들
+export type ApiResultCategoryResponse = ApiResult<CategoryResponse>
+export type ApiResultListCategoryResponse = ApiResult<CategoryResponse[]>
+export type ApiResultTemplateResponse = ApiResult<TemplateResponse>
+export type ApiResultListTemplateSummaryResponse = ApiResult<TemplateSummaryResponse[]>
+export type ApiResultListTemplatesByCategoryResponse = ApiResult<TemplatesByCategoryResponse[]>
+export type ApiResultDocumentResponse = ApiResult<DocumentResponse>
+export type ApiResultPageDocumentSummaryResponse = ApiResult<PageResult<DocumentSummaryResponse>>
+export type ApiResultDocumentCommentResponse = ApiResult<DocumentCommentResponse>
+export type ApiResultListDocumentCommentResponse = ApiResult<DocumentCommentResponse[]>
+export type ApiResultVoid = ApiResult<void>

--- a/lib/services/common/api-client.ts
+++ b/lib/services/common/api-client.ts
@@ -1,0 +1,56 @@
+import axios from 'axios'
+
+// API 기본 설정
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:9000'
+
+// Axios 인스턴스 생성
+export const apiClient = axios.create({
+  baseURL: API_BASE_URL,
+  timeout: 30000,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+})
+
+// 요청 인터셉터 - 인증 토큰 추가
+apiClient.interceptors.request.use(
+  (config) => {
+    // 로컬 스토리지나 쿠키에서 토큰을 가져오는 로직
+    const token = typeof window !== 'undefined' ? localStorage.getItem('auth_token') : null
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`
+    }
+    return config
+  },
+  (error) => {
+    return Promise.reject(error)
+  }
+)
+
+// 응답 인터셉터 - 에러 처리
+apiClient.interceptors.response.use(
+  (response) => {
+    return response
+  },
+  (error) => {
+    // 401 에러시 로그인 페이지로 리다이렉트
+    if (error.response?.status === 401) {
+      if (typeof window !== 'undefined') {
+        localStorage.removeItem('auth_token')
+        window.location.href = '/login'
+      }
+    }
+    
+    // 에러 메시지 표준화
+    const errorMessage = error.response?.data?.message || error.message || 'Unknown error occurred'
+    
+    return Promise.reject({
+      ...error,
+      message: errorMessage,
+      status: error.response?.status,
+      data: error.response?.data
+    })
+  }
+)
+
+export default apiClient

--- a/lib/services/common/index.ts
+++ b/lib/services/common/index.ts
@@ -1,0 +1,4 @@
+// 공통 서비스 관련 모든 exports를 한 곳에서 관리
+export * from './types'
+export * from './api-client'
+export { default as apiClient } from './api-client'

--- a/lib/services/common/types.ts
+++ b/lib/services/common/types.ts
@@ -1,0 +1,49 @@
+// 공통 API 응답 타입
+export interface ApiResult<T> {
+  status: string
+  message: string
+  data: T
+}
+
+// 페이지네이션 관련 타입
+export interface Pageable {
+  page: number
+  size: number
+  sort?: string[]
+}
+
+export interface SortObject {
+  empty: boolean
+  sorted: boolean
+  unsorted: boolean
+}
+
+export interface PageableObject {
+  offset: number
+  sort: SortObject
+  unpaged: boolean
+  paged: boolean
+  pageSize: number
+  pageNumber: number
+}
+
+export interface PageResult<T> {
+  totalPages: number
+  totalElements: number
+  size: number
+  content: T[]
+  number: number
+  sort: SortObject
+  first: boolean
+  last: boolean
+  numberOfElements: number
+  pageable: PageableObject
+  empty: boolean
+}
+
+// 공통 에러 타입
+export interface ApiError {
+  message: string
+  status?: number
+  data?: any
+}

--- a/lib/services/index.ts
+++ b/lib/services/index.ts
@@ -1,0 +1,2 @@
+export * from './common'
+export * from './approval'


### PR DESCRIPTION
closes [잘못된 Next.js API Routes 사용](#88)

## 클라이언트에서 Spring Boot로 직접 호출하는 구조로 변경

### 새로운 구조
```
클라이언트 (React Components)
    ↓ (lib/services)
Spring Boot API Server
```

### lib/services 구조
```
lib/services/
├── common/
│   ├── api-client.ts      # Axios 클라이언트 설정
│   └── types.ts           # 공통 타입 정의
├── user/
│   ├── types.ts           # 사용자 서비스 관련 타입
│   └── api.ts             # 사용자 API 함수들
├── approval/
│   ├── types.ts           # 결재 서비스 관련 타입
│   └── api.ts             # 결재 API 함수들
├── ...
└── index.ts               # 전체 서비스 exports
```