### PR TITLE
글로벌 챗봇 컴포넌트 추가 및 동료 근무표 연동 기능 구현 + UI/UX 개선 & 스케줄 시스템 통합

### DIFF
--- a/app/aichat/GlobalAIChat.tsx
+++ b/app/aichat/GlobalAIChat.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useState } from "react";
+import Chatbot from "./components/Chatbot";
+import ChatbotSticker from "./components/ChatbotSticker";
+
+export default function GlobalAIChat(): JSX.Element {
+  const [isChatOpen, setIsChatOpen] = useState<boolean>(false);
+
+  return (
+    <div>
+      <ChatbotSticker
+        isOpen={isChatOpen}
+        onToggle={() => setIsChatOpen((v) => !v)}
+      />
+      {isChatOpen && (
+        <div className="fixed bottom-4 right-4 z-50">
+          <Chatbot onClose={() => setIsChatOpen(false)} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,18 +1,19 @@
-import type { Metadata } from 'next'
-import { GeistSans } from 'geist/font/sans'
-import { GeistMono } from 'geist/font/mono'
-import './globals.css'
-import { Toaster } from 'sonner'
-import { AuthProvider } from '@/contexts/auth-context'
+import type { Metadata } from "next";
+import { GeistSans } from "geist/font/sans";
+import { GeistMono } from "geist/font/mono";
+import "./globals.css";
+import { Toaster } from "sonner";
+import { AuthProvider } from "@/contexts/auth-context";
+import GlobalAIChat from "./aichat/GlobalAIChat";
 
 export const metadata: Metadata = {
-  title: 'Hermes'
-}
+  title: "Hermes",
+};
 
 export default function RootLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode
+  children: React.ReactNode;
 }>) {
   return (
     <html lang="en">
@@ -28,14 +29,15 @@ html {
       <body>
         <AuthProvider>
           {children}
+          {/* Global AI Chat visible on all pages */}
+          {/* @ts-expect-error Server Component import of client component in layout */}
+          <div>
+            {/* This wrapper keeps portal-like fixed positioning working */}
+            <GlobalAIChat />
+          </div>
         </AuthProvider>
-        <Toaster 
-          position="top-center"
-          richColors
-          closeButton
-          duration={4000}
-        />
+        <Toaster position="top-center" richColors closeButton duration={4000} />
       </body>
     </html>
-  )
+  );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -38,6 +38,7 @@ import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { attendanceApi, workMonitorApi } from "@/lib/services/attendance";
 import { useAuth } from "@/hooks/use-auth";
+import { formatKstTime } from "@/lib/utils/datetime";
 
 interface Employee {
   id: string;
@@ -197,11 +198,7 @@ export default function DashboardPage() {
       }
 
       const now = new Date();
-      const checkInDisplay = now.toLocaleTimeString("ko-KR", {
-        hour: "2-digit",
-        minute: "2-digit",
-        hour12: false,
-      });
+      const checkInDisplay = formatKstTime(now);
 
       const res = await attendanceApi.checkIn({
         userId: Number(user.id),
@@ -235,11 +232,7 @@ export default function DashboardPage() {
       }
 
       const now = new Date();
-      const checkOutDisplay = now.toLocaleTimeString("ko-KR", {
-        hour: "2-digit",
-        minute: "2-digit",
-        hour12: false,
-      });
+      const checkOutDisplay = formatKstTime(now);
 
       const res = await attendanceApi.checkOut({
         userId: Number(user.id),

--- a/app/settings/workpolicies/create/page.tsx
+++ b/app/settings/workpolicies/create/page.tsx
@@ -142,6 +142,7 @@ export default function CreateWorkPolicyPage(): JSX.Element {
         end: string;
       }>) || [{ start: "12:00", end: "13:00" }];
       const breakStartTime = toTimeString(breakTimes[0]?.start);
+      const breakEndTime = toTimeString(breakTimes[0]?.end);
 
       const totalRequiredMinutes = workHours * 60 + workMinutes;
 
@@ -149,7 +150,9 @@ export default function CreateWorkPolicyPage(): JSX.Element {
         name,
         type,
         workCycle: undefined as WorkCycle | undefined,
-        startDayOfWeek: toEnumDay(String(policyData.cycleStartDay || "monday")) as DayOfWeek, 
+        startDayOfWeek: toEnumDay(
+          String(policyData.cycleStartDay || "monday")
+        ) as DayOfWeek,
         workCycleStartDay: undefined as number | undefined,
         workDays,
         weeklyWorkingDays,
@@ -160,6 +163,7 @@ export default function CreateWorkPolicyPage(): JSX.Element {
         coreTimeStart: undefined,
         coreTimeEnd: undefined,
         breakStartTime, // string "HH:mm:ss"
+        breakEndTime, // string "HH:mm:ss"
         avgWorkTime: undefined,
         totalRequiredMinutes,
         annualLeaves: undefined,

--- a/app/work/components/CoworkerComponent.tsx
+++ b/app/work/components/CoworkerComponent.tsx
@@ -30,10 +30,12 @@ import { userApi } from "@/lib/services/user/api";
 import { ColleagueResponseDto } from "@/lib/services/user/types";
 import { workScheduleApi } from "@/lib/services/attendance/api";
 import {
+  SCHEDULE_TYPE_COLOR,
   toLabelFromEnum,
   toColorFromEnum,
   toTimeString,
 } from "./schedule-utils";
+import "./schedulecalendar.css";
 
 // Type definitions
 interface CoworkerEvent {
@@ -330,7 +332,7 @@ export default function CoworkerComponent(): JSX.Element {
           type: string
         ): { title: string; color: string } => {
           const title = toLabelFromEnum(type, type);
-          const color = toColorFromEnum(type, "#94a3b8");
+          const color = SCHEDULE_TYPE_COLOR[type] || "#94a3b8";
           return { title, color };
         };
 
@@ -449,7 +451,6 @@ export default function CoworkerComponent(): JSX.Element {
       {/* Header with Search and Filters */}
       <div className="flex items-center justify-between mb-6">
         <div className="flex items-center gap-4">
-          <h1 className="text-2xl font-bold text-gray-800">동료 근무표</h1>
         </div>
         <div className="flex items-center gap-2">
           <Search className="w-4 h-4 text-gray-400" />
@@ -511,17 +512,17 @@ export default function CoworkerComponent(): JSX.Element {
 
       {/* Calendar */}
       <GlassCard className="p-6">
-        <div className="calendar-container">
+        <div className="calendar-container schedule-calendar-container">
           {isClient && (
             <ScheduleCalendar
               events={events}
-              onEventDrop={() => {}}
-              onEventResize={() => {}}
-              onSelect={() => {}}
-              onEventClick={() => {}}
+              onEventDrop={() => {}} // 드래그 이동 비활성화
+              onEventResize={() => {}} // 크기 조정 비활성화
+              onSelect={() => {}} // 드래그 선택 비활성화
+              onEventClick={() => {}} // 이벤트 클릭 비활성화
               dayCellDidMount={() => {}}
               eventContent={eventContent}
-              editable={false}
+              editable={false} // 편집 비활성화 (드래그, 리사이즈, 선택 모두 비활성화)
             />
           )}
         </div>

--- a/app/work/components/CoworkerComponent.tsx
+++ b/app/work/components/CoworkerComponent.tsx
@@ -18,7 +18,6 @@ import {
   Mail,
   Phone,
 } from "lucide-react";
-import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { MainLayout } from "@/components/layout/main-layout";
@@ -27,6 +26,14 @@ import { GlassCard } from "@/components/ui/glass-card";
 import { colors } from "@/lib/design-tokens";
 import { useRouter } from "next/navigation";
 import dynamic from "next/dynamic";
+import { userApi } from "@/lib/services/user/api";
+import { ColleagueResponseDto } from "@/lib/services/user/types";
+import { workScheduleApi } from "@/lib/services/attendance/api";
+import {
+  toLabelFromEnum,
+  toColorFromEnum,
+  toTimeString,
+} from "./schedule-utils";
 
 // Type definitions
 interface CoworkerEvent {
@@ -203,16 +210,6 @@ const EditableEvent = ({
   );
 };
 
-// 유형 ↔ 색상 매핑
-const TYPE_COLORS: { [key: string]: string } = {
-  근무: "#4FC3F7",
-  재택: "#B39DDB",
-  외근: "#AED581",
-  출장: "#FFB74D",
-  휴가: "#F48FB1",
-  휴게: "#B2DFDB",
-};
-
 export default function CoworkerComponent(): JSX.Element {
   const [currentWeek, setCurrentWeek] = useState<string>("");
   const [events, setEvents] = useState<CoworkerEvent[]>([]);
@@ -226,67 +223,50 @@ export default function CoworkerComponent(): JSX.Element {
 
   const router = useRouter();
 
-  // 샘플 직원 데이터
-  const sampleEmployees: Employee[] = [
-    {
-      id: "1",
-      name: "김철수",
-      position: "개발자",
-      department: "개발팀",
-      email: "kim@company.com",
-      phone: "010-1234-5678",
-      status: "online",
-      workType: "근무",
-    },
-    {
-      id: "2",
-      name: "이영희",
-      position: "디자이너",
-      department: "디자인팀",
-      email: "lee@company.com",
-      phone: "010-2345-6789",
-      status: "away",
-      workType: "재택",
-    },
-    {
-      id: "3",
-      name: "박민수",
-      position: "기획자",
-      department: "기획팀",
-      email: "park@company.com",
-      phone: "010-3456-7890",
-      status: "offline",
-      workType: "외근",
-    },
-    {
-      id: "4",
-      name: "최지영",
-      position: "마케터",
-      department: "마케팅팀",
-      email: "choi@company.com",
-      phone: "010-4567-8901",
-      status: "online",
-      workType: "출장",
-    },
-  ];
+  // API 동료 → UI Employee 변환
+  const mapColleagueToEmployee = (c: ColleagueResponseDto): Employee => ({
+    id: String(c.userId),
+    name: c.name,
+    position: c.position ?? "",
+    department: c.department ?? "",
+    email: c.email,
+    phone: c.phoneNumber,
+    avatar: c.avatar,
+    status: (c.status as Employee["status"]) ?? "offline",
+    workType: undefined,
+  });
 
   // 클라이언트 사이드에서만 실행
   useEffect(() => {
     setIsClient(true);
-    setEmployees(sampleEmployees);
-    setFilteredEmployees(sampleEmployees);
   }, []);
 
-  // 검색 필터링
+  // 동료 검색 (마운트 및 검색어 변경 시)
   useEffect(() => {
-    const filtered = employees.filter(
-      (employee) =>
-        employee.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        employee.department.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        employee.position.toLowerCase().includes(searchTerm.toLowerCase())
-    );
-    setFilteredEmployees(filtered);
-  }, [searchTerm, employees]);
+    if (!isClient) return;
+
+    const controller = new AbortController();
+    const handler = setTimeout(async () => {
+      try {
+        const data = await userApi.getColleagues({
+          searchKeyword: searchTerm || undefined,
+          page: 0,
+          size: 20,
+        });
+        const mapped = data.map(mapColleagueToEmployee);
+        setEmployees(mapped);
+        setFilteredEmployees(mapped);
+      } catch (e) {
+        setEmployees([]);
+        setFilteredEmployees([]);
+      }
+    }, 300);
+
+    return () => {
+      controller.abort();
+      clearTimeout(handler);
+    };
+  }, [isClient, searchTerm]);
 
   // baseDate를 기준으로 주차 계산
   useEffect(() => {
@@ -320,113 +300,96 @@ export default function CoworkerComponent(): JSX.Element {
     setWeekDates(weekMapping);
   }, [isClient, baseDate]);
 
-  // 현재 주 기준으로 scheduleData 생성
-  const generateScheduleData = (): ScheduleData => {
-    const today = new Date();
-    const currentDay = today.getDay();
-    const mondayOffset = currentDay === 0 ? -6 : 1 - currentDay;
-    const monday = new Date(today);
-    monday.setDate(today.getDate() + mondayOffset);
-
-    const scheduleData: ScheduleData = {};
-
-    for (let i = 0; i < 7; i++) {
-      const currentDate = new Date(monday);
-      currentDate.setDate(monday.getDate() + i);
-      const dayKey = currentDate.getDate();
-      const dayOfWeek = currentDate.getDay();
-
-      if (dayOfWeek >= 1 && dayOfWeek <= 5) {
-        // 평일: 다양한 근무 유형으로 구성
-        const workTypes = ["근무", "재택", "외근", "출장"];
-        const randomType =
-          workTypes[Math.floor(Math.random() * workTypes.length)];
-
-        scheduleData[dayKey] = [
-          {
-            startTime: "09:00",
-            endTime: "12:00",
-            title: randomType,
-            color: TYPE_COLORS[randomType],
-            type: "work",
-            employeeId: "1",
-          },
-          {
-            startTime: "12:00",
-            endTime: "13:00",
-            title: "휴게",
-            color: TYPE_COLORS.휴게,
-            type: "break",
-            employeeId: "1",
-          },
-          {
-            startTime: "13:00",
-            endTime: "18:00",
-            title: randomType,
-            color: TYPE_COLORS[randomType],
-            type: "work",
-            employeeId: "1",
-          },
-        ];
-      } else {
-        scheduleData[dayKey] = [
-          {
-            title: "휴가",
-            color: TYPE_COLORS.휴가,
-            type: "vacation",
-            employeeId: "1",
-          },
-        ];
-      }
-    }
-    return scheduleData;
-  };
-
   // scheduleData → FullCalendar events 변환
   useEffect(() => {
     if (!isClient || !currentWeek || Object.keys(weekDates).length === 0)
       return;
 
-    const scheduleData = generateScheduleData();
-    const convertedEvents: CoworkerEvent[] = [];
+    const targetId =
+      selectedEmployee === "all" ? employees[0]?.id ?? "1" : selectedEmployee;
+    const targetName =
+      employees.find((e) => e.id === targetId)?.name ||
+      employees[0]?.name ||
+      "직원";
 
-    Object.entries(scheduleData).forEach(([day, events]) => {
-      const dateString = weekDates[parseInt(day)];
+    const dates = Object.values(weekDates);
+    const startDate = dates.sort()[0];
+    const endDate = dates.sort()[dates.length - 1];
 
-      events.forEach((event: ScheduleEvent, index: number) => {
-        let startTime: string, endTime: string, allDay: boolean;
+    let isCancelled = false;
 
-        if (event.startTime && event.endTime) {
-          startTime = `${dateString}T${event.startTime}:00`;
-          endTime = `${dateString}T${event.endTime}:00`;
-          allDay = false;
-        } else {
-          startTime = `${dateString}T09:00:00`;
-          endTime = `${dateString}T18:00:00`;
-          allDay = true;
+    const fetchSchedules = async () => {
+      try {
+        const data = await workScheduleApi.getColleagueSchedule(
+          Number(targetId),
+          startDate,
+          endDate
+        );
+
+        const mapTypeToLabelAndColor = (
+          type: string
+        ): { title: string; color: string } => {
+          const title = toLabelFromEnum(type, type);
+          const color = toColorFromEnum(type, "#94a3b8");
+          return { title, color };
+        };
+
+        const converted: CoworkerEvent[] = [];
+
+        // 안전한 null 체크
+        if (!data || !data.dailySchedules) {
+          console.warn("동료 스케줄 데이터가 없습니다:", data);
+          if (!isCancelled) {
+            setEvents([]);
+          }
+          return;
         }
 
-        const eventObj: CoworkerEvent = {
-          id: `${day}-${index}`,
-          title: event.title,
-          start: startTime,
-          end: endTime,
-          backgroundColor: event.color,
-          borderColor: event.color,
-          textColor: "#ffffff",
-          allDay: allDay,
-          extendedProps: {
-            employeeId: event.employeeId,
-            employeeName: "김철수",
-            type: event.type,
-          },
-        };
-        convertedEvents.push(eventObj);
-      });
-    });
+        data.dailySchedules.forEach((daily) => {
+          const dateStr = daily.date; // YYYY-MM-DD
+          // events 배열 null 체크
+          if (!daily.events || !Array.isArray(daily.events)) {
+            return;
+          }
+          daily.events.forEach((evt, idx) => {
+            const { title, color } = mapTypeToLabelAndColor(evt.scheduleType);
+            const start = `${dateStr}T${toTimeString(evt.startTime)}`;
+            const end = `${dateStr}T${toTimeString(evt.endTime)}`;
+            converted.push({
+              id: `${evt.scheduleType}-${dateStr}-${idx}`,
+              title,
+              start,
+              end,
+              backgroundColor: color,
+              borderColor: color,
+              textColor: "#ffffff",
+              allDay: false,
+              extendedProps: {
+                employeeId: String(targetId),
+                employeeName: targetName,
+                type: evt.scheduleType,
+              },
+            });
+          });
+        });
 
-    setEvents(convertedEvents);
-  }, [isClient, currentWeek, weekDates]);
+        if (!isCancelled) {
+          setEvents(converted);
+        }
+      } catch (e) {
+        console.error("스케줄 조회 실패:", e);
+        if (!isCancelled) {
+          setEvents([]);
+        }
+      }
+    };
+
+    fetchSchedules();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [isClient, currentWeek, weekDates, selectedEmployee, employees]);
 
   const handlePreviousWeek = (): void => {
     const newBaseDate = new Date(baseDate);
@@ -487,38 +450,21 @@ export default function CoworkerComponent(): JSX.Element {
       <div className="flex items-center justify-between mb-6">
         <div className="flex items-center gap-4">
           <h1 className="text-2xl font-bold text-gray-800">동료 근무표</h1>
-          <div className="flex items-center gap-2">
-            <Search className="w-4 h-4 text-gray-400" />
-            <Input
-              placeholder="직원 검색..."
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-64"
-            />
-          </div>
         </div>
         <div className="flex items-center gap-2">
-          <Button
-            variant={selectedEmployee === "all" ? "default" : "outline"}
-            onClick={() => handleEmployeeSelect("all")}
-          >
-            전체
-          </Button>
-          {filteredEmployees.slice(0, 3).map((employee) => (
-            <Button
-              key={employee.id}
-              variant={selectedEmployee === employee.id ? "default" : "outline"}
-              onClick={() => handleEmployeeSelect(employee.id)}
-            >
-              {employee.name}
-            </Button>
-          ))}
+          <Search className="w-4 h-4 text-gray-400" />
+          <Input
+            placeholder="직원 검색..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            className="w-64"
+          />
         </div>
       </div>
 
-      {/* Employee List */}
+      {/* Employee List (상위 4명 미리보기) */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
-        {filteredEmployees.map((employee) => (
+        {filteredEmployees.slice(0, 4).map((employee) => (
           <GlassCard
             key={employee.id}
             className={`p-4 cursor-pointer transition-all duration-200 hover:shadow-lg ${

--- a/app/work/components/MyWorkComponent.tsx
+++ b/app/work/components/MyWorkComponent.tsx
@@ -11,6 +11,12 @@ import dynamic from "next/dynamic";
 import { workScheduleApi } from "@/lib/services/attendance";
 import { useAuth } from "@/hooks/use-auth";
 import { ScheduleType } from "@/lib/services/attendance";
+import {
+  SCHEDULE_TYPE_LABEL,
+  SCHEDULE_TYPE_COLOR,
+  toLabelFromEnum,
+  toColorFromEnum,
+} from "./schedule-utils";
 
 // Type definitions
 interface WorkEvent {
@@ -93,49 +99,6 @@ const ScheduleCalendar = dynamic(
   }
 );
 
-// 유형 ↔ 색상 매핑 (Backend ScheduleType 기준)
-const TYPE_COLORS: Record<ScheduleType, string> = {
-  [ScheduleType.WORK]: "#4FC3F7",
-  [ScheduleType.SICK_LEAVE]: "#F48FB1",
-  [ScheduleType.VACATION]: "#F48FB1",
-  [ScheduleType.BUSINESS_TRIP]: "#FFB74D",
-  [ScheduleType.OUT_OF_OFFICE]: "#AED581",
-  [ScheduleType.OVERTIME]: "#B39DDB",
-  [ScheduleType.RESTTIME]: "#90CAF9",
-};
-
-// Backend ScheduleType(enum) → 한글 라벨 매핑
-const SCHEDULE_TYPE_LABEL: Record<string, string> = {
-  WORK: "근무",
-  SICK_LEAVE: "병가",
-  VACATION: "휴가",
-  BUSINESS_TRIP: "출장",
-  OUT_OF_OFFICE: "외근",
-  OVERTIME: "초과근무",
-  RESTTIME: "휴게시간",
-};
-
-// Backend ScheduleType(enum) → 색상 매핑 (TYPE_COLORS 재사용)
-const SCHEDULE_TYPE_COLOR: Record<string, string> = {
-  WORK: TYPE_COLORS[ScheduleType.WORK],
-  SICK_LEAVE: TYPE_COLORS[ScheduleType.SICK_LEAVE],
-  VACATION: TYPE_COLORS[ScheduleType.VACATION],
-  BUSINESS_TRIP: TYPE_COLORS[ScheduleType.BUSINESS_TRIP],
-  OUT_OF_OFFICE: TYPE_COLORS[ScheduleType.OUT_OF_OFFICE],
-  OVERTIME: TYPE_COLORS[ScheduleType.OVERTIME],
-  RESTTIME: TYPE_COLORS[ScheduleType.RESTTIME],
-};
-
-const toLabelFromEnum = (scheduleType?: string, fallback?: string): string => {
-  if (!scheduleType) return fallback || "";
-  return SCHEDULE_TYPE_LABEL[scheduleType] || fallback || scheduleType;
-};
-
-const toColorFromEnum = (scheduleType?: string, fallback?: string): string => {
-  if (!scheduleType) return fallback || "#4FC3F7";
-  return SCHEDULE_TYPE_COLOR[scheduleType] || fallback || "#4FC3F7";
-};
-
 export default function MyWorkComponent(): JSX.Element {
   const { user } = useAuth();
   const [currentWeek, setCurrentWeek] = useState<string>("");
@@ -160,34 +123,6 @@ export default function MyWorkComponent(): JSX.Element {
   });
 
   const router = useRouter();
-
-  // 정해진 시간 범위에서 시간 생성 (예시)
-  const timeRanges: TimeRange[] = [
-    { start: "09:00", end: "11:00" },
-    { start: "13:00", end: "15:00" },
-    { start: "15:30", end: "17:00" },
-    { start: "10:00", end: "12:00" },
-    { start: "14:00", end: "16:00" },
-    { start: "16:30", end: "18:00" },
-  ];
-
-  // 요일별 시간 패턴 설정
-  const getTimePatternForDay = (dayOfWeek: number): TimePattern[] => {
-    switch (dayOfWeek) {
-      case 1:
-      case 2:
-      case 3:
-      case 4:
-      case 5:
-        return [
-          { start: "08:00", end: "12:00", title: "근무", type: "work" },
-          { start: "12:00", end: "13:30", title: "휴게", type: "break" },
-          { start: "13:30", end: "18:00", title: "근무", type: "work" },
-        ];
-      default:
-        return [];
-    }
-  };
 
   // 클라이언트 사이드에서만 실행
   useEffect(() => {
@@ -226,9 +161,9 @@ export default function MyWorkComponent(): JSX.Element {
     setWeekDates(weekMapping);
   }, [isClient, baseDate]);
 
-  // 정책을 반영하여 해당 주의 고정 스케줄을 생성하고, 스케줄 불러오기
+  // 스케줄 불러오기 (정책 적용 없이 단순 조회)
   useEffect(() => {
-    const syncSchedulesWithPolicy = async () => {
+    const loadSchedules = async () => {
       try {
         if (!user?.id || !isClient) return;
 
@@ -251,14 +186,7 @@ export default function MyWorkComponent(): JSX.Element {
         const startDate = toStr(monday);
         const endDate = toStr(sunday);
 
-        // Work Policy를 스케줄에 반영 (근무/휴게/코어/시차 등 전체 반영)
-        await workScheduleApi.applyWorkPolicyToSchedule(
-          Number(user.id),
-          startDate,
-          endDate
-        );
-
-        // 기간 스케줄 조회
+        // 기간 스케줄 조회 (정책 적용 없이)
         const schedules = await workScheduleApi.getUserSchedulesByDateRange(
           Number(user.id),
           startDate,
@@ -310,11 +238,11 @@ export default function MyWorkComponent(): JSX.Element {
         setOriginalEvents(mapped);
       } catch (e) {
         // 실패해도 화면은 유지
-        console.error("Failed to sync schedules with policy:", e);
+        console.error("Failed to load schedules:", e);
       }
     };
 
-    syncSchedulesWithPolicy();
+    loadSchedules();
   }, [user?.id, isClient, baseDate]);
 
   // 현재 주 기준으로 scheduleData 생성
@@ -528,16 +456,6 @@ export default function MyWorkComponent(): JSX.Element {
           return `${hh}:${mm}:00`;
         };
 
-        // 임시 디버그: 전송 userId와 로그인 user.id 일치 여부 확인
-        console.debug(
-          "[work] create payload userId=",
-          Number(user.id),
-          "startDate=",
-          startDate,
-          "endDate=",
-          endDate
-        );
-
         const created = await workScheduleApi.createSchedule({
           userId: Number(user.id),
           title: newEvent.title,
@@ -665,8 +583,7 @@ export default function MyWorkComponent(): JSX.Element {
     if (!target) return;
 
     const label = toLabelFromEnum(selectedType, selectedType);
-    const selectedColor =
-      TYPE_COLORS[selectedType as unknown as ScheduleType] || "#4FC3F7";
+    const selectedColor = SCHEDULE_TYPE_COLOR[selectedType] || "#4FC3F7";
 
     // Optimistic update
     const prev = target;

--- a/app/work/components/MyWorkComponent.tsx
+++ b/app/work/components/MyWorkComponent.tsx
@@ -286,8 +286,10 @@ export default function MyWorkComponent(): JSX.Element {
           const endHHmm = timeToHHmm(s.endTime) || "18:00";
           const start = `${s.startDate}T${startHHmm}:00`;
           const end = `${s.endDate}T${endHHmm}:00`;
-          const title =
-            s.title || toLabelFromEnum(s.scheduleType, s.scheduleType);
+          const title = toLabelFromEnum(
+            s.scheduleType,
+            s.title || s.scheduleType
+          );
           const color = s.color || toColorFromEnum(s.scheduleType, "#4FC3F7");
           return {
             id: String(s.id),
@@ -474,27 +476,148 @@ export default function MyWorkComponent(): JSX.Element {
       return;
     }
 
+    // Client-side overlap check
+    const selStart = selectInfo.start as Date;
+    const selEnd = selectInfo.end as Date;
+    const conflicts = events.some((e) => {
+      const es = new Date(e.start);
+      const ee = new Date(e.end);
+      return es < selEnd && selStart < ee; // overlap if existing.start < selEnd && selStart < existing.end
+    });
+    if (conflicts) {
+      alert(
+        "선택한 시간이 기존 스케줄과 겹칩니다. 다른 시간대를 선택해 주세요."
+      );
+      return;
+    }
+
     const calendarApi = selectInfo.view.calendar;
+    const tempId = new Date().getTime().toString();
     const newEvent: WorkEvent = {
-      id: new Date().getTime().toString(),
+      id: tempId,
       title: "근무",
       start: selectInfo.startStr,
       end: selectInfo.endStr,
       allDay: selectInfo.allDay,
-      backgroundColor: "#3b82f6", // 임시 기본색 (선택 후 바뀜)
+      backgroundColor: "#3b82f6",
       borderColor: "#3b82f6",
       textColor: "#ffffff",
       status: "pending",
-      isNewEvent: true, // 새 이벤트 식별자 (extendedProps로 들어감)
+      isNewEvent: true,
       extendedProps: {
         isNewEvent: true,
       },
     };
 
+    // Optimistic add
     calendarApi.addEvent(newEvent);
     setEvents((prev) => [...prev, newEvent]);
     setHasPendingChanges(true);
     calendarApi.unselect();
+
+    // Persist to backend
+    (async () => {
+      try {
+        if (!user?.id) return;
+        const startDate = newEvent.start.slice(0, 10);
+        const endDate = newEvent.end.slice(0, 10);
+        const toHHmmss = (iso: string) => {
+          const d = new Date(iso);
+          const hh = String(d.getHours()).padStart(2, "0");
+          const mm = String(d.getMinutes()).padStart(2, "0");
+          return `${hh}:${mm}:00`;
+        };
+
+        // 임시 디버그: 전송 userId와 로그인 user.id 일치 여부 확인
+        console.debug(
+          "[work] create payload userId=",
+          Number(user.id),
+          "startDate=",
+          startDate,
+          "endDate=",
+          endDate
+        );
+
+        const created = await workScheduleApi.createSchedule({
+          userId: Number(user.id),
+          title: newEvent.title,
+          description: undefined,
+          startDate,
+          endDate,
+          startTime: toHHmmss(newEvent.start),
+          endTime: toHHmmss(newEvent.end),
+          scheduleType: ScheduleType.WORK,
+          color: newEvent.backgroundColor,
+          isAllDay: !!newEvent.allDay,
+          isRecurring: false,
+        });
+
+        // Map server response to event and replace temp
+        const start = `${created.startDate}${
+          created.startTime
+            ? "T" +
+              String(created.startTime.hour).padStart(2, "0") +
+              ":" +
+              String(created.startTime.minute).padStart(2, "0") +
+              ":00"
+            : "T09:00:00"
+        }`;
+        const end = `${created.endDate}${
+          created.endTime
+            ? "T" +
+              String(created.endTime.hour).padStart(2, "0") +
+              ":" +
+              String(created.endTime.minute).padStart(2, "0") +
+              ":00"
+            : "T18:00:00"
+        }`;
+        const title = toLabelFromEnum(
+          created.scheduleType,
+          created.title || created.scheduleType
+        );
+        const color =
+          created.color || toColorFromEnum(created.scheduleType, "#4FC3F7");
+
+        const savedEvent: WorkEvent = {
+          id: String(created.id),
+          title,
+          start,
+          end,
+          backgroundColor: color,
+          borderColor: color,
+          textColor: "#1f2937",
+          allDay: created.isAllDay,
+          extendedProps: {
+            originalTitle: created.title,
+            type: created.scheduleType,
+          },
+        } as WorkEvent;
+
+        // Replace temp event
+        setEvents((prev) =>
+          prev.filter((e) => e.id !== tempId).concat(savedEvent)
+        );
+        // Update calendar instance
+        const temp = calendarApi.getEventById(tempId);
+        if (temp) temp.remove();
+        calendarApi.addEvent(savedEvent as any);
+        setHasPendingChanges(false);
+      } catch (err: any) {
+        console.error(
+          "Failed to create schedule:",
+          err,
+          err?.data,
+          err?.response
+        );
+        // Revert optimistic event
+        setEvents((prev) => prev.filter((e) => e.id !== tempId));
+        const temp = calendarApi.getEventById(tempId);
+        if (temp) temp.remove();
+        const msg =
+          err?.message || err?.data?.message || "근무 생성에 실패했습니다.";
+        alert(msg);
+      }
+    })();
   };
 
   const handleEventClick = (clickInfo: any): void => {
@@ -538,24 +661,67 @@ export default function MyWorkComponent(): JSX.Element {
 
   // 드롭다운에서 유형 선택 시 호출: 색상은 매핑에서 조회
   const handleTitleSelect = (eventId: string, selectedType: string): void => {
-    const selectedColor = TYPE_COLORS[selectedType as ScheduleType];
-    const updated = events.map((event) => {
-      if (event.id === eventId) {
-        return {
-          ...event,
-          title: selectedType,
-          backgroundColor: selectedColor,
-          borderColor: selectedColor,
-          status: "pending",
-          isNewEvent: false, // 이후 변경 불가
-        };
-      }
-      return event;
-    });
-    setEvents(updated);
+    const target = events.find((e) => e.id === eventId);
+    if (!target) return;
+
+    const label = toLabelFromEnum(selectedType, selectedType);
+    const selectedColor =
+      TYPE_COLORS[selectedType as unknown as ScheduleType] || "#4FC3F7";
+
+    // Optimistic update
+    const prev = target;
+    const optimistic: WorkEvent = {
+      ...target,
+      title: label,
+      backgroundColor: selectedColor,
+      borderColor: selectedColor,
+      status: "pending",
+      isNewEvent: false,
+      extendedProps: {
+        ...target.extendedProps,
+        type: selectedType,
+      },
+    };
+    setEvents((list) => list.map((e) => (e.id === eventId ? optimistic : e)));
     setShowDropdown(false);
     setDropdownEventId(null);
-    setHasPendingChanges(true);
+
+    // Persist to backend if event has a numeric id (saved on server)
+    const isPersisted = !isNaN(Number(eventId));
+    if (!user?.id || !isPersisted) {
+      return;
+    }
+
+    const toHHmmss = (iso: string) => {
+      const d = new Date(iso);
+      const hh = String(d.getHours()).padStart(2, "0");
+      const mm = String(d.getMinutes()).padStart(2, "0");
+      return `${hh}:${mm}:00`;
+    };
+
+    (async () => {
+      try {
+        const startDate = optimistic.start.slice(0, 10);
+        const endDate = optimistic.end.slice(0, 10);
+        await workScheduleApi.updateSchedule(Number(user.id), Number(eventId), {
+          title: label,
+          description: undefined,
+          startDate,
+          endDate,
+          startTime: toHHmmss(optimistic.start),
+          endTime: toHHmmss(optimistic.end),
+          scheduleType: selectedType as unknown as ScheduleType,
+          color: selectedColor,
+          isAllDay: !!optimistic.allDay,
+          isRecurring: false,
+        });
+      } catch (err) {
+        console.error("Failed to update schedule type:", err);
+        // Revert
+        setEvents((list) => list.map((e) => (e.id === eventId ? prev : e)));
+        alert("근무 유형 변경에 실패했습니다.");
+      }
+    })();
   };
 
   // 드롭다운 메뉴 컴포넌트 (텍스트만, fixed 포지셔닝, 내부 클릭 보호)
@@ -570,7 +736,15 @@ export default function MyWorkComponent(): JSX.Element {
     onSelect: (eventId: string, selectedType: string) => void;
     onClose: () => void;
   }): JSX.Element => {
-    const options = ["근무", "재택", "외근", "출장", "휴가", "휴게"];
+    const options = [
+      { key: "WORK", label: SCHEDULE_TYPE_LABEL.WORK },
+      { key: "OUT_OF_OFFICE", label: SCHEDULE_TYPE_LABEL.OUT_OF_OFFICE },
+      { key: "BUSINESS_TRIP", label: SCHEDULE_TYPE_LABEL.BUSINESS_TRIP },
+      { key: "VACATION", label: SCHEDULE_TYPE_LABEL.VACATION },
+      { key: "SICK_LEAVE", label: SCHEDULE_TYPE_LABEL.SICK_LEAVE },
+      { key: "OVERTIME", label: SCHEDULE_TYPE_LABEL.OVERTIME },
+      { key: "RESTTIME", label: SCHEDULE_TYPE_LABEL.RESTTIME },
+    ];
     const ref = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
@@ -606,10 +780,10 @@ export default function MyWorkComponent(): JSX.Element {
         }}
         onClick={(e) => e.stopPropagation()}
       >
-        {options.map((label) => (
+        {options.map((opt) => (
           <button
-            key={label}
-            onClick={() => onSelect(eventId, label)}
+            key={opt.key}
+            onClick={() => onSelect(eventId, opt.key)}
             style={{
               cursor: "pointer",
               background: "white",
@@ -627,7 +801,7 @@ export default function MyWorkComponent(): JSX.Element {
               (e.currentTarget.style.backgroundColor = "white")
             }
           >
-            {label}
+            {opt.label}
           </button>
         ))}
       </div>
@@ -637,13 +811,11 @@ export default function MyWorkComponent(): JSX.Element {
   // SimpleEvent: 제목 클릭 → 드롭다운을 제목 바로 아래에 표시
   const SimpleEvent = ({ event }: { event: WorkEvent }): JSX.Element => {
     const handleTitleClick = (e: React.MouseEvent): void => {
-      if (event.extendedProps?.isNewEvent) {
-        e.stopPropagation();
-        const rect = e.currentTarget.getBoundingClientRect();
-        setDropdownPosition({ x: rect.left, y: rect.bottom + 5 }); // 텍스트 바로 아래
-        setDropdownEventId(event.id);
-        setShowDropdown(true);
-      }
+      e.stopPropagation();
+      const rect = e.currentTarget.getBoundingClientRect();
+      setDropdownPosition({ x: rect.left, y: rect.bottom + 5 }); // 텍스트 바로 아래
+      setDropdownEventId(event.id);
+      setShowDropdown(true);
     };
 
     return (

--- a/app/work/components/MyWorkComponent.tsx
+++ b/app/work/components/MyWorkComponent.tsx
@@ -101,6 +101,7 @@ const TYPE_COLORS: Record<ScheduleType, string> = {
   [ScheduleType.BUSINESS_TRIP]: "#FFB74D",
   [ScheduleType.OUT_OF_OFFICE]: "#AED581",
   [ScheduleType.OVERTIME]: "#B39DDB",
+  [ScheduleType.RESTTIME]: "#90CAF9",
 };
 
 // Backend ScheduleType(enum) → 한글 라벨 매핑
@@ -111,6 +112,7 @@ const SCHEDULE_TYPE_LABEL: Record<string, string> = {
   BUSINESS_TRIP: "출장",
   OUT_OF_OFFICE: "외근",
   OVERTIME: "초과근무",
+  RESTTIME: "휴게시간",
 };
 
 // Backend ScheduleType(enum) → 색상 매핑 (TYPE_COLORS 재사용)
@@ -121,6 +123,7 @@ const SCHEDULE_TYPE_COLOR: Record<string, string> = {
   BUSINESS_TRIP: TYPE_COLORS[ScheduleType.BUSINESS_TRIP],
   OUT_OF_OFFICE: TYPE_COLORS[ScheduleType.OUT_OF_OFFICE],
   OVERTIME: TYPE_COLORS[ScheduleType.OVERTIME],
+  RESTTIME: TYPE_COLORS[ScheduleType.RESTTIME],
 };
 
 const toLabelFromEnum = (scheduleType?: string, fallback?: string): string => {
@@ -283,10 +286,8 @@ export default function MyWorkComponent(): JSX.Element {
           const endHHmm = timeToHHmm(s.endTime) || "18:00";
           const start = `${s.startDate}T${startHHmm}:00`;
           const end = `${s.endDate}T${endHHmm}:00`;
-          const title = toLabelFromEnum(
-            s.scheduleType,
-            s.title || s.scheduleType
-          );
+          const title =
+            s.title || toLabelFromEnum(s.scheduleType, s.scheduleType);
           const color = s.color || toColorFromEnum(s.scheduleType, "#4FC3F7");
           return {
             id: String(s.id),

--- a/app/work/components/MyWorkComponent.tsx
+++ b/app/work/components/MyWorkComponent.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { Calendar, Users, Clock, TrendingUp } from "lucide-react";
+import { Calendar, Users, Clock, TrendingUp, Trash2 } from "lucide-react";
 import { MainLayout } from "@/components/layout/main-layout";
 import { DateNavigation } from "@/components/ui/date-navigation";
 import { GlassCard } from "@/components/ui/glass-card";
@@ -17,6 +17,7 @@ import {
   toLabelFromEnum,
   toColorFromEnum,
 } from "./schedule-utils";
+import "./schedulecalendar.css";
 
 // Type definitions
 interface WorkEvent {
@@ -218,7 +219,7 @@ export default function MyWorkComponent(): JSX.Element {
             s.scheduleType,
             s.title || s.scheduleType
           );
-          const color = s.color || toColorFromEnum(s.scheduleType, "#4FC3F7");
+          const color = SCHEDULE_TYPE_COLOR[s.scheduleType] || "#4FC3F7";
           return {
             id: String(s.id),
             title,
@@ -264,62 +265,7 @@ export default function MyWorkComponent(): JSX.Element {
     return scheduleData;
   };
 
-  // scheduleData → FullCalendar events 변환
-  useEffect(() => {
-    if (!isClient || !currentWeek || Object.keys(weekDates).length === 0)
-      return;
-
-    const scheduleData = generateScheduleData();
-    const convertedEvents: WorkEvent[] = [];
-
-    Object.entries(scheduleData).forEach(([day, events]) => {
-      const dateString = weekDates[parseInt(day)];
-
-      events.forEach((event: ScheduleEvent, index: number) => {
-        let startTime: string, endTime: string, allDay: boolean;
-
-        if (event.startTime && event.endTime) {
-          startTime = `${dateString}T${event.startTime}:00`;
-          endTime = `${dateString}T${event.endTime}:00`;
-          allDay = false;
-        } else if (event.time) {
-          startTime = `${dateString}T${event.time}:00`;
-          const endDate = new Date(`${dateString}T${event.time}:00`);
-          endDate.setMinutes(endDate.getMinutes() + 30);
-          endTime = endDate.toISOString();
-          allDay = false;
-        } else {
-          startTime = `${dateString}T09:00:00`;
-          endTime = `${dateString}T18:00:00`;
-          allDay = true;
-        }
-
-        const eventObj: WorkEvent = {
-          id: `${day}-${index}`,
-          title: event.title,
-          start: startTime,
-          end: endTime,
-          backgroundColor: event.color,
-          borderColor: event.color,
-          textColor: "#ffffff",
-          allDay: allDay,
-          extendedProps: {
-            originalTime: event.time,
-            originalStartTime: event.startTime,
-            originalEndTime: event.endTime,
-            originalTitle: event.title,
-            originalColor: event.color,
-            isAllDayRest: event.isAllDayRest || false,
-            type: event.type || "unknown",
-          },
-        };
-        convertedEvents.push(eventObj);
-      });
-    });
-
-    setEvents(convertedEvents);
-    setOriginalEvents(convertedEvents);
-  }, [isClient, currentWeek, weekDates]);
+  // 이 useEffect는 제거 - 서버에서 가져온 실제 데이터를 사용
 
   // 근무 시간 계산 (근무, 외근, 출장, 재택 모두 포함, 휴가 제외)
   const calculateWorkTime = (events: WorkEvent[]): WorkTimeSummary => {
@@ -363,6 +309,8 @@ export default function MyWorkComponent(): JSX.Element {
   const handleEventDrop = (info: any): void => {
     if (info.event.start.getDay() === 0) {
       alert("일요일에는 일정을 이동할 수 없습니다.");
+      // 이벤트를 원래 위치로 되돌리기
+      info.revert();
       return;
     }
     const updated = events.map((event) =>
@@ -382,6 +330,8 @@ export default function MyWorkComponent(): JSX.Element {
   const handleEventResize = (info: any): void => {
     if (info.event.start.getDay() === 0) {
       alert("일요일에는 일정을 수정할 수 없습니다.");
+      // 이벤트를 원래 크기로 되돌리기
+      info.revert();
       return;
     }
     const updated = events.map((event) =>
@@ -401,6 +351,8 @@ export default function MyWorkComponent(): JSX.Element {
   const handleSelect = (selectInfo: any): void => {
     if (selectInfo.start.getDay() === 0) {
       alert("일요일에는 일정을 추가할 수 없습니다.");
+      // 선택 영역 해제
+      selectInfo.view.calendar.unselect();
       return;
     }
 
@@ -421,14 +373,15 @@ export default function MyWorkComponent(): JSX.Element {
 
     const calendarApi = selectInfo.view.calendar;
     const tempId = new Date().getTime().toString();
+    const workColor = SCHEDULE_TYPE_COLOR.WORK || "#4FC3F7";
     const newEvent: WorkEvent = {
       id: tempId,
       title: "근무",
       start: selectInfo.startStr,
       end: selectInfo.endStr,
       allDay: selectInfo.allDay,
-      backgroundColor: "#3b82f6",
-      borderColor: "#3b82f6",
+      backgroundColor: workColor,
+      borderColor: workColor,
       textColor: "#ffffff",
       status: "pending",
       isNewEvent: true,
@@ -493,8 +446,7 @@ export default function MyWorkComponent(): JSX.Element {
           created.scheduleType,
           created.title || created.scheduleType
         );
-        const color =
-          created.color || toColorFromEnum(created.scheduleType, "#4FC3F7");
+        const color = SCHEDULE_TYPE_COLOR[created.scheduleType] || "#4FC3F7";
 
         const savedEvent: WorkEvent = {
           id: String(created.id),
@@ -539,20 +491,44 @@ export default function MyWorkComponent(): JSX.Element {
   };
 
   const handleEventClick = (clickInfo: any): void => {
-    if (clickInfo.event.start.getDay() === 0) {
+    // 이벤트 클릭 시에는 아무것도 하지 않음 (삭제는 쓰레기통 아이콘으로만)
+    return;
+  };
+
+  const handleDeleteEvent = (
+    eventId: string,
+    event: React.MouseEvent
+  ): void => {
+    event.stopPropagation(); // 이벤트 버블링 방지
+
+    const targetEvent = events.find((e) => e.id === eventId);
+    if (!targetEvent) return;
+
+    const eventDate = new Date(targetEvent.start);
+    if (eventDate.getDay() === 0) {
       alert("일요일에는 일정을 삭제할 수 없습니다.");
       return;
     }
+
     if (confirm("이 일정을 삭제하시겠습니까?")) {
-      clickInfo.event.remove();
-      setEvents((prev) => prev.filter((e) => e.id !== clickInfo.event.id));
+      // 캘린더에서 이벤트 제거
+      const calendarApi = document
+        .querySelector(".fc")
+        ?.querySelector(".fc-view")?.parentElement;
+      if (calendarApi) {
+        const fcEvent = (calendarApi as any).calendar?.getEventById(eventId);
+        if (fcEvent) fcEvent.remove();
+      }
+
+      // 상태에서 이벤트 제거
+      setEvents((prev) => prev.filter((e) => e.id !== eventId));
       setHasPendingChanges(true);
     }
   };
 
   const dayCellDidMountHandler = (arg: any): void => {
     if (arg.date.getDay() === 0) {
-      arg.el.style.backgroundColor = "#ffe5e5";
+      arg.el.classList.add("sunday-disabled");
     }
   };
 
@@ -683,17 +659,10 @@ export default function MyWorkComponent(): JSX.Element {
     return (
       <div
         ref={ref}
+        className="fixed z-50 bg-white border border-gray-300 rounded-md shadow-lg overflow-hidden whitespace-nowrap"
         style={{
-          position: "fixed",
           left,
           top,
-          zIndex: 1000,
-          backgroundColor: "white",
-          border: "1px solid #d1d5db",
-          borderRadius: "6px",
-          boxShadow: "0 4px 8px rgba(0,0,0,0.1)",
-          overflow: "hidden",
-          whiteSpace: "nowrap", // 텍스트 줄바꿈 방지
         }}
         onClick={(e) => e.stopPropagation()}
       >
@@ -701,22 +670,7 @@ export default function MyWorkComponent(): JSX.Element {
           <button
             key={opt.key}
             onClick={() => onSelect(eventId, opt.key)}
-            style={{
-              cursor: "pointer",
-              background: "white",
-              display: "block",
-              width: "100%",
-              textAlign: "left",
-              padding: "4px 8px", // 패딩 줄임
-              fontSize: "13px", // 글씨 크기 약간 줄임
-              borderBottom: "1px solid #f3f4f6",
-            }}
-            onMouseEnter={(e) =>
-              (e.currentTarget.style.backgroundColor = "#f9fafb")
-            }
-            onMouseLeave={(e) =>
-              (e.currentTarget.style.backgroundColor = "white")
-            }
+            className="block w-full text-left px-2 py-1 text-sm border-b border-gray-100 bg-white hover:bg-gray-50 cursor-pointer"
           >
             {opt.label}
           </button>
@@ -725,7 +679,7 @@ export default function MyWorkComponent(): JSX.Element {
     );
   };
 
-  // SimpleEvent: 제목 클릭 → 드롭다운을 제목 바로 아래에 표시
+  // SimpleEvent: 제목 클릭 → 드롭다운, 쓰레기통 클릭 → 삭제
   const SimpleEvent = ({ event }: { event: WorkEvent }): JSX.Element => {
     const handleTitleClick = (e: React.MouseEvent): void => {
       e.stopPropagation();
@@ -746,27 +700,63 @@ export default function MyWorkComponent(): JSX.Element {
           position: "relative",
         }}
       >
-        {/* 시간 표시 */}
+        {/* 상단 영역: 시간 + 삭제 버튼 */}
         <div
           style={{
-            fontSize: "10px",
-            color: "rgba(255, 255, 255, 0.9)",
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
             marginBottom: "2px",
-            fontWeight: "normal",
-            lineHeight: "1",
           }}
         >
-          {new Date(event.start).toLocaleTimeString("ko-KR", {
-            hour: "2-digit",
-            minute: "2-digit",
-            hour12: false,
-          })}{" "}
-          -{" "}
-          {new Date(event.end).toLocaleTimeString("ko-KR", {
-            hour: "2-digit",
-            minute: "2-digit",
-            hour12: false,
-          })}
+          {/* 시간 표시 */}
+          <div
+            style={{
+              fontSize: "10px",
+              color: "rgba(255, 255, 255, 0.9)",
+              fontWeight: "normal",
+              lineHeight: "1",
+              flex: 1,
+            }}
+          >
+            {new Date(event.start).toLocaleTimeString("ko-KR", {
+              hour: "2-digit",
+              minute: "2-digit",
+              hour12: false,
+            })}{" "}
+            -{" "}
+            {new Date(event.end).toLocaleTimeString("ko-KR", {
+              hour: "2-digit",
+              minute: "2-digit",
+              hour12: false,
+            })}
+          </div>
+
+          {/* 삭제 버튼 */}
+          <button
+            onClick={(e) => handleDeleteEvent(event.id, e)}
+            style={{
+              background: "rgba(255, 255, 255, 0.2)",
+              border: "none",
+              borderRadius: "3px",
+              padding: "2px",
+              cursor: "pointer",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              width: "16px",
+              height: "16px",
+              flexShrink: 0,
+            }}
+            title="일정 삭제"
+          >
+            <Trash2
+              size={10}
+              style={{
+                color: "rgba(255, 255, 255, 0.9)",
+              }}
+            />
+          </button>
         </div>
 
         {/* 제목 (클릭 시 드롭다운) */}
@@ -875,17 +865,6 @@ export default function MyWorkComponent(): JSX.Element {
         <div className="w-80 flex-shrink-0 -mt-6">
           <GlassCard className="p-4 border-2 border-gray-300 shadow-none">
             <div className="flex items-center space-x-3 mb-3">
-              <div className="p-2 bg-blue-100 rounded-lg">
-                <Clock className="w-5 h-5 text-blue-600" />
-              </div>
-              <div>
-                <h3 className="text-sm font-semibold text-gray-800">
-                  이번주 근무 현황
-                </h3>
-                <p className="text-xs text-gray-600">
-                  근무 시간 및 목표 달성률
-                </p>
-              </div>
             </div>
             <WorkTimeGauge
               percentage={workTimeSummary.percentage}
@@ -898,7 +877,7 @@ export default function MyWorkComponent(): JSX.Element {
 
       {/* FullCalendar Schedule */}
       <GlassCard className="p-6">
-        <div className="calendar-container">
+        <div className="calendar-container schedule-calendar-container">
           {isClient && (
             <ScheduleCalendar
               events={events}

--- a/app/work/components/schedule-utils.ts
+++ b/app/work/components/schedule-utils.ts
@@ -10,16 +10,16 @@ export const SCHEDULE_TYPE_LABEL: Record<string, string> = {
   REMOTE: "재택", // CoworkerComponent에서 사용
 };
 
-// Backend ScheduleType(enum) → 색상 매핑
+// Backend ScheduleType(enum) → 색상 매핑 (모두 구분 가능한 색상)
 export const SCHEDULE_TYPE_COLOR: Record<string, string> = {
-  WORK: "#4FC3F7",
-  SICK_LEAVE: "#F48FB1",
-  VACATION: "#F48FB1",
-  BUSINESS_TRIP: "#FFB74D",
-  OUT_OF_OFFICE: "#AED581",
-  OVERTIME: "#B39DDB",
-  RESTTIME: "#B2DFDB", // CoworkerComponent와 일치하도록 수정
-  REMOTE: "#B39DDB",
+  WORK: "#3B82F6", // 파란색 (기본 근무)
+  SICK_LEAVE: "#EF4444", // 빨간색 (병가)
+  VACATION: "#F59E0B", // 주황색 (휴가)
+  BUSINESS_TRIP: "#8B5CF6", // 보라색 (출장)
+  OUT_OF_OFFICE: "#10B981", // 초록색 (외근)
+  OVERTIME: "#EC4899", // 핑크색 (초과근무)
+  RESTTIME: "#06B6D4", // 청록색 (휴게시간)
+  REMOTE: "#84CC16", // 라임색 (재택)
 };
 
 // ScheduleType → 한글 라벨 변환 함수

--- a/app/work/components/schedule-utils.ts
+++ b/app/work/components/schedule-utils.ts
@@ -1,0 +1,53 @@
+// Backend ScheduleType(enum) → 한글 라벨 매핑
+export const SCHEDULE_TYPE_LABEL: Record<string, string> = {
+  WORK: "근무",
+  SICK_LEAVE: "병가",
+  VACATION: "휴가",
+  BUSINESS_TRIP: "출장",
+  OUT_OF_OFFICE: "외근",
+  OVERTIME: "초과근무",
+  RESTTIME: "휴게시간",
+  REMOTE: "재택", // CoworkerComponent에서 사용
+};
+
+// Backend ScheduleType(enum) → 색상 매핑
+export const SCHEDULE_TYPE_COLOR: Record<string, string> = {
+  WORK: "#4FC3F7",
+  SICK_LEAVE: "#F48FB1",
+  VACATION: "#F48FB1",
+  BUSINESS_TRIP: "#FFB74D",
+  OUT_OF_OFFICE: "#AED581",
+  OVERTIME: "#B39DDB",
+  RESTTIME: "#B2DFDB", // CoworkerComponent와 일치하도록 수정
+  REMOTE: "#B39DDB",
+};
+
+// ScheduleType → 한글 라벨 변환 함수
+export const toLabelFromEnum = (
+  scheduleType?: string,
+  fallback?: string
+): string => {
+  if (!scheduleType) return fallback || "";
+  return SCHEDULE_TYPE_LABEL[scheduleType] || fallback || scheduleType;
+};
+
+// ScheduleType → 색상 변환 함수
+export const toColorFromEnum = (
+  scheduleType?: string,
+  fallback?: string
+): string => {
+  if (!scheduleType) return fallback || "#4FC3F7";
+  return SCHEDULE_TYPE_COLOR[scheduleType] || fallback || "#4FC3F7";
+};
+
+// 시간 변환 함수 (LocalTime 객체 또는 문자열 → HH:mm:ss)
+export const toTimeString = (
+  t?: string | { hour: number; minute: number; second: number }
+): string => {
+  if (!t) return "00:00:00";
+  if (typeof t === "string") return t; // "09:00:00" 형태
+  const hh = String(t.hour).padStart(2, "0");
+  const mm = String(t.minute).padStart(2, "0");
+  const ss = String(t.second).padStart(2, "0");
+  return `${hh}:${mm}:${ss}`;
+};

--- a/app/work/components/schedulecalendar.css
+++ b/app/work/components/schedulecalendar.css
@@ -1,0 +1,61 @@
+/* 스케줄 캘린더 관련 스타일 */
+
+/* 일요일 비활성화 스타일 */
+.sunday-disabled {
+  background-color: #fef2f2; /* bg-red-50과 동일 */
+  position: relative;
+}
+
+.sunday-disabled::after {
+  content: "일정 추가 불가";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 12px;
+  color: #dc2626;
+  background-color: rgba(255, 255, 255, 0.9);
+  padding: 4px 8px;
+  border-radius: 4px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.sunday-disabled:hover::after {
+  opacity: 1;
+}
+
+/* 일요일 컬럼 전체 스타일 */
+.fc-day-sun {
+  cursor: not-allowed !important;
+}
+
+.fc-day-sun .fc-timegrid-col-frame {
+  background-color: #fef2f2 !important;
+}
+
+/* 추가적인 캘린더 스타일들 */
+.schedule-calendar-container {
+  width: 100%;
+  height: 100%;
+}
+
+/* 이벤트 호버 효과 */
+.fc-event:hover {
+  opacity: 0.9;
+  transform: translateY(-1px);
+  transition: all 0.2s ease;
+}
+
+/* 드래그 중인 이벤트 스타일 */
+.fc-event-dragging {
+  opacity: 0.7;
+  z-index: 999;
+}
+
+/* 선택 영역 스타일 */
+.fc-highlight {
+  background-color: rgba(59, 130, 246, 0.1);
+  border: 2px dashed rgba(59, 130, 246, 0.3);
+}

--- a/components/calendar/schedule-calendar.jsx
+++ b/components/calendar/schedule-calendar.jsx
@@ -129,13 +129,51 @@ export default function ScheduleCalendar({
             info.el.style.bottom = "0";
           }
 
-          if (
+          const isBreak =
             info.event.title === "휴게" ||
             info.event.title === "휴게시간" ||
             info.event.extendedProps?.type === "break" ||
-            info.event.extendedProps?.type === "RESTTIME"
-          ) {
+            info.event.extendedProps?.type === "RESTTIME";
+
+          if (isBreak) {
             info.el.style.boxShadow = "0 6px 16px rgba(0,0,0,.18)";
+            // 위치 계산 이후 보정: 다음 프레임에서 DOM 조정
+            requestAnimationFrame(() => {
+              const harness = info.el.closest(".fc-timegrid-event-harness");
+              if (harness) {
+                harness.style.removeProperty("left");
+                harness.style.removeProperty("right");
+                harness.style.removeProperty("width");
+                harness.style.removeProperty("transform");
+                harness.style.removeProperty("margin-left");
+
+                harness.style.setProperty("left", "0", "important");
+                harness.style.setProperty("right", "0", "important");
+                harness.style.setProperty("width", "100%", "important");
+                harness.style.setProperty("transform", "none", "important");
+                harness.style.setProperty("z-index", "60", "important");
+
+                const inset = harness.querySelector(
+                  ".fc-timegrid-event-harness-inset"
+                );
+                if (inset) {
+                  inset.style.removeProperty("left");
+                  inset.style.removeProperty("right");
+                  inset.style.removeProperty("width");
+                  inset.style.removeProperty("transform");
+                  inset.style.removeProperty("margin-left");
+
+                  inset.style.setProperty("left", "0", "important");
+                  inset.style.setProperty("right", "0", "important");
+                  inset.style.setProperty("width", "100%", "important");
+                  inset.style.setProperty("transform", "none", "important");
+                }
+              }
+
+              info.el.style.setProperty("left", "0", "important");
+              info.el.style.setProperty("right", "0", "important");
+              info.el.style.setProperty("width", "100%", "important");
+            });
           }
         }}
         /* 위치 계산이 끝난 직후 최종 보정: 부모 래퍼의 left/width/transform 제거 및 고정 */

--- a/components/calendar/schedule-calendar.jsx
+++ b/components/calendar/schedule-calendar.jsx
@@ -85,8 +85,14 @@ export default function ScheduleCalendar({
         firstDay={0}
         weekends={true}
         nowIndicator={true}
-        selectable={true}
-        selectMirror={true}
+        selectable={editable}
+        selectMirror={editable}
+        selectConstraint={{
+          daysOfWeek: [1, 2, 3, 4, 5, 6], // 월~토만 선택 가능 (일요일 제외)
+        }}
+        eventConstraint={{
+          daysOfWeek: [1, 2, 3, 4, 5, 6], // 월~토만 이벤트 이동 가능 (일요일 제외)
+        }}
         dayMaxEvents={true}
         moreLinkClick="popover"
         eventTimeFormat={{

--- a/components/calendar/schedule-calendar.jsx
+++ b/components/calendar/schedule-calendar.jsx
@@ -106,8 +106,12 @@ export default function ScheduleCalendar({
           return (
             aTitle === "휴게" ||
             bTitle === "휴게" ||
+            aTitle === "휴게시간" ||
+            bTitle === "휴게시간" ||
             aType === "break" ||
-            bType === "break"
+            bType === "break" ||
+            aType === "RESTTIME" ||
+            bType === "RESTTIME"
           );
         }}
         slotEventOverlap={true}
@@ -127,7 +131,9 @@ export default function ScheduleCalendar({
 
           if (
             info.event.title === "휴게" ||
-            info.event.extendedProps?.type === "break"
+            info.event.title === "휴게시간" ||
+            info.event.extendedProps?.type === "break" ||
+            info.event.extendedProps?.type === "RESTTIME"
           ) {
             info.el.style.boxShadow = "0 6px 16px rgba(0,0,0,.18)";
           }
@@ -136,7 +142,9 @@ export default function ScheduleCalendar({
         eventPositioned={(info) => {
           const isBreak =
             info.event.title === "휴게" ||
-            info.event.extendedProps?.type === "break";
+            info.event.title === "휴게시간" ||
+            info.event.extendedProps?.type === "break" ||
+            info.event.extendedProps?.type === "RESTTIME";
           if (!isBreak) return;
 
           const harness = info.el.closest(".fc-timegrid-event-harness");

--- a/lib/services/attendance/api.ts
+++ b/lib/services/attendance/api.ts
@@ -146,7 +146,12 @@ export const workScheduleApi = {
       "/api/work-schedule/schedules",
       request
     );
-    return response.data.data;
+    const result = response.data;
+    if (!result || result.status !== "success" || !result.data) {
+      const msg = result?.message || "스케줄 생성 실패";
+      throw { message: msg, data: result };
+    }
+    return result.data;
   },
 
   // 스케줄 조회 (사용자별)
@@ -242,9 +247,9 @@ export const workScheduleApi = {
     endDate: string
   ): Promise<ColleagueScheduleResponseDto> => {
     const params = new URLSearchParams({ startDate, endDate });
-    const response = await apiClient.get<ApiResult<ColleagueScheduleResponseDto>>(
-      `/api/work-schedule/colleagues/${colleagueId}/schedules?${params}`
-    );
+    const response = await apiClient.get<
+      ApiResult<ColleagueScheduleResponseDto>
+    >(`/api/work-schedule/colleagues/${colleagueId}/schedules?${params}`);
     return response.data.data;
   },
 

--- a/lib/services/attendance/types.ts
+++ b/lib/services/attendance/types.ts
@@ -135,8 +135,8 @@ export interface CreateScheduleRequestDto {
   description?: string;
   startDate: string;
   endDate: string;
-  startTime?: LocalTime;
-  endTime?: LocalTime;
+  startTime?: string; // HH:mm:ss
+  endTime?: string; // HH:mm:ss
   scheduleType: ScheduleType;
   color?: string;
   isAllDay: boolean;
@@ -158,8 +158,8 @@ export interface UpdateScheduleRequestDto {
   description?: string;
   startDate: string;
   endDate: string;
-  startTime?: LocalTime;
-  endTime?: LocalTime;
+  startTime?: string; // HH:mm:ss
+  endTime?: string; // HH:mm:ss
   scheduleType: ScheduleType;
   color?: string;
   isAllDay: boolean;

--- a/lib/services/attendance/types.ts
+++ b/lib/services/attendance/types.ts
@@ -35,6 +35,7 @@ export enum ScheduleType {
   BUSINESS_TRIP = "BUSINESS_TRIP",
   OUT_OF_OFFICE = "OUT_OF_OFFICE",
   OVERTIME = "OVERTIME",
+  RESTTIME = "RESTTIME",
 }
 
 // 근무 정책 타입 열거형
@@ -419,4 +420,3 @@ export interface ApiResult<T> {
   message: string;
   data: T;
 }
-

--- a/lib/utils/datetime.ts
+++ b/lib/utils/datetime.ts
@@ -1,0 +1,45 @@
+export const KST_TZ = "Asia/Seoul";
+
+export function formatKstTime(
+  instantIso?: string | Date,
+  fallback: string = ""
+): string {
+  if (!instantIso) return fallback;
+  const d = instantIso instanceof Date ? instantIso : new Date(instantIso);
+  if (Number.isNaN(d.getTime())) return fallback;
+  return d.toLocaleTimeString("ko-KR", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: undefined,
+    hour12: false,
+    timeZone: KST_TZ,
+  });
+}
+
+export function formatKstDate(
+  instantIso?: string | Date,
+  fallback: string = ""
+): string {
+  if (!instantIso) return fallback;
+  const d = instantIso instanceof Date ? instantIso : new Date(instantIso);
+  if (Number.isNaN(d.getTime())) return fallback;
+  return d.toLocaleDateString("ko-KR", { timeZone: KST_TZ });
+}
+
+export function formatKstDateTime(
+  instantIso?: string | Date,
+  fallback: string = ""
+): string {
+  if (!instantIso) return fallback;
+  const d = instantIso instanceof Date ? instantIso : new Date(instantIso);
+  if (Number.isNaN(d.getTime())) return fallback;
+  const date = d.toLocaleDateString("ko-KR", { timeZone: KST_TZ });
+  const time = d.toLocaleTimeString("ko-KR", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+    timeZone: KST_TZ,
+  });
+  return `${date} ${time}`;
+}


### PR DESCRIPTION
## 🧩 이슈  번호 

- close #69 

## ✅ 작업 사항 

- app/aichat/GlobalAIChat.tsx 추가: 스티커 + 챗봇 토글 전역 컴포넌트
- app/layout.tsx에 GlobalAIChat 포함하여 모든 페이지에서 노출
- 스티커 클릭 시 챗봇 창 열림/닫힘 동작 구현
- ScheduleType에 RESTTIME 반영(types.ts)
- MyWorkComponent: RESTTIME 라벨/색상 매핑 추가, 서버 title 우선 사용으로 “휴게시간” 정확히 표기
- schedule-calendar: RESTTIME을 휴게로 간주하여 겹침 허용 및 스타일 적용

- 동료 선택 및 근무표 연동 기능 추가
  * 동료 카드 클릭 시 selectedEmployee 상태 업데이트
  * 선택된 동료의 userId로 스케줄 API 호출
  * 동료별 근무표 실시간 전환 기능 구현

- UI/UX 개선
  * 선택된 동료 카드 하이라이트 표시 (ring-2 ring-blue-500)
  * 동료 정보 카드 hover 효과 추가
  * 캘린더에 선택된 동료의 스케줄 표시

- 상태 관리 최적화
  * selectedEmployee 상태와 API 호출 연동
  * 동료 변경 시 자동 스케줄 재조회
  * 로딩 상태 및 오류 처리 개선
- 스케줄 색상 매핑 시스템 통일 (SCHEDULE_TYPE_COLOR 직접 참조)
- 모든 스케줄 타입별 구분 가능한 색상으로 변경
- 근무 삭제 UI를 쓰레기통 아이콘으로 개선
- 동료 근무표 완전 읽기 전용 설정 (드래그/편집 차단)
- 일요일 근무 블럭 추가 방지 및 자동 되돌리기 기능
- 하드코딩된 색상/스타일 제거 및 CSS 모듈화
- schedulecalendar.css 파일로 스타일 중앙 관리
- FullCalendar 제약 조건 강화 (selectConstraint, eventConstraint)

## 📸 스크린샷 (선택)

## 💬 공유사항

<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
