### PR TITLE
근무 정책 설정에 연차 정책 카드 생성

### DIFF
--- a/app/settings/workpolicies/components/FixedWorkForm.tsx
+++ b/app/settings/workpolicies/components/FixedWorkForm.tsx
@@ -12,12 +12,26 @@ import {
 import { Button } from "@/components/ui/button";
 import { Calendar, Plus } from "lucide-react";
 import SelectTime from "@/components/clock/SelectTime";
-import { DayOfWeek, WorkPolicyType } from "@/lib/services/attendance";
+import {
+  DayOfWeek,
+  WorkPolicyType,
+  AnnualLeaveRequestDto,
+} from "@/lib/services/attendance";
 
 // Type definitions
+interface AnnualLeavePolicy {
+  id?: string;
+  name: string;
+  minYears: number;
+  maxYears: number;
+  leaveDays: number;
+  holidayDays: number;
+}
+
 interface FormData {
   [key: string]: any;
   workName?: string;
+  annualLeaves?: AnnualLeavePolicy[];
   workingDays?: Record<string, boolean>;
   weeklyHoliday?: Record<string, boolean>;
   cycleStartDay?: string;
@@ -82,6 +96,39 @@ export function FixedWorkForm({
 
   const openTimePicker = (field: keyof TimePickerState): void => {
     setShowTimePicker((prev) => ({ ...prev, [field]: true }));
+  };
+
+  // 연차 정책 관리 함수들
+  const addAnnualLeave = (): void => {
+    const newPolicy: AnnualLeavePolicy = {
+      id: Date.now().toString(),
+      name: `정책 ${(formData.annualLeaves || []).length + 1}`,
+      minYears: 0,
+      maxYears: 1,
+      leaveDays: 15,
+      holidayDays: 0,
+    };
+
+    const currentPolicies = formData.annualLeaves || [];
+    updateFormData("annualLeaves", [...currentPolicies, newPolicy]);
+  };
+
+  const removeAnnualLeave = (index: number): void => {
+    const currentPolicies = formData.annualLeaves || [];
+    const updatedPolicies = currentPolicies.filter((_, i) => i !== index);
+    updateFormData("annualLeaves", updatedPolicies);
+  };
+
+  const updateAnnualLeave = (
+    index: number,
+    field: keyof AnnualLeavePolicy,
+    value: string | number
+  ): void => {
+    const currentPolicies = formData.annualLeaves || [];
+    const updatedPolicies = currentPolicies.map((policy, i) =>
+      i === index ? { ...policy, [field]: value } : policy
+    );
+    updateFormData("annualLeaves", updatedPolicies);
   };
 
   const closeTimePicker = (field: keyof TimePickerState): void => {
@@ -421,6 +468,133 @@ export function FixedWorkForm({
           >
             <Plus className="w-4 h-4" />
             추가하기
+          </Button>
+        </div>
+      </div>
+
+      {/* 연차 정책 설정 */}
+      <div className="space-y-4 bg-white/50 backdrop-blur-sm p-4 rounded-lg border border-gray-200/50">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            연차 설정
+          </label>
+          {(formData.annualLeaves || []).map((policy, index) => (
+            <div
+              key={policy.id || index}
+              className="grid grid-cols-10 gap-2 mb-3 p-3 bg-gray-50 rounded-lg"
+            >
+              {/* 최소 근무년수 */}
+              <div className="col-span-3">
+                <label className="block text-xs text-gray-600 mb-1">
+                  최소 년수
+                </label>
+                <Input
+                  type="number"
+                  value={policy.minYears}
+                  onChange={(e) =>
+                    updateAnnualLeave(
+                      index,
+                      "minYears",
+                      parseInt(e.target.value) || 0
+                    )
+                  }
+                  min="0"
+                  className="text-sm"
+                />
+              </div>
+
+              {/* 최대 근무년수 */}
+              <div className="col-span-3">
+                <label className="block text-xs text-gray-600 mb-1">
+                  최대 년수
+                </label>
+                <Input
+                  type="number"
+                  value={policy.maxYears}
+                  onChange={(e) =>
+                    updateAnnualLeave(
+                      index,
+                      "maxYears",
+                      parseInt(e.target.value) || 0
+                    )
+                  }
+                  min="0"
+                  className="text-sm"
+                />
+              </div>
+
+              {/* 연차 일수 */}
+              <div className="col-span-2">
+                <label className="block text-xs text-gray-600 mb-1">
+                  연차 일수
+                </label>
+                <Input
+                  type="number"
+                  value={policy.leaveDays}
+                  onChange={(e) =>
+                    updateAnnualLeave(
+                      index,
+                      "leaveDays",
+                      parseInt(e.target.value) || 0
+                    )
+                  }
+                  min="0"
+                  max="365"
+                  className="text-sm"
+                />
+              </div>
+
+              {/* 휴일 일수 */}
+              <div className="col-span-1">
+                <label className="block text-xs text-gray-600 mb-1">휴일</label>
+                <Input
+                  type="number"
+                  value={policy.holidayDays}
+                  onChange={(e) =>
+                    updateAnnualLeave(
+                      index,
+                      "holidayDays",
+                      parseInt(e.target.value) || 0
+                    )
+                  }
+                  min="0"
+                  className="text-sm"
+                />
+              </div>
+
+              {/* 삭제 버튼 */}
+              <div className="col-span-1 flex items-end">
+                {(formData.annualLeaves || []).length > 1 && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => removeAnnualLeave(index)}
+                    className="text-red-500 hover:text-red-700 px-2"
+                  >
+                    ×
+                  </Button>
+                )}
+              </div>
+
+              {/* 표시 텍스트 */}
+              <div className="col-span-10 mt-2">
+                <p className="text-xs text-gray-600">
+                  근무 {policy.minYears}년 ~ {policy.maxYears}년: 연차{" "}
+                  {policy.leaveDays}일
+                  {policy.holidayDays > 0 && `, 휴일 ${policy.holidayDays}일`}
+                </p>
+              </div>
+            </div>
+          ))}
+
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={addAnnualLeave}
+            className="flex items-center gap-2 mt-2"
+          >
+            <Plus className="w-4 h-4" />
+            연차 정책 추가
           </Button>
         </div>
       </div>

--- a/app/settings/workpolicies/components/SelectWorkForm.tsx
+++ b/app/settings/workpolicies/components/SelectWorkForm.tsx
@@ -10,11 +10,22 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
-import { Calendar } from "lucide-react";
+import { Calendar, Plus } from "lucide-react";
+import { AnnualLeaveRequestDto } from "@/lib/services/attendance";
 
 // Type definitions
+interface AnnualLeavePolicy {
+  id?: string;
+  name: string;
+  minYears: number;
+  maxYears: number;
+  leaveDays: number;
+  holidayDays: number;
+}
+
 interface FormData {
   [key: string]: any;
+  annualLeaves?: AnnualLeavePolicy[];
 }
 
 interface SelectWorkFormProps {
@@ -28,6 +39,39 @@ export function SelectWorkForm({
 }: SelectWorkFormProps): React.ReactElement {
   const updateFormData = (field: string, value: any): void => {
     setFormData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  // 연차 정책 관리 함수들
+  const addAnnualLeave = (): void => {
+    const newPolicy: AnnualLeavePolicy = {
+      id: Date.now().toString(),
+      name: `정책 ${(formData.annualLeaves || []).length + 1}`,
+      minYears: 0,
+      maxYears: 1,
+      leaveDays: 15,
+      holidayDays: 0,
+    };
+
+    const currentPolicies = formData.annualLeaves || [];
+    updateFormData("annualLeaves", [...currentPolicies, newPolicy]);
+  };
+
+  const removeAnnualLeave = (index: number): void => {
+    const currentPolicies = formData.annualLeaves || [];
+    const updatedPolicies = currentPolicies.filter((_, i) => i !== index);
+    updateFormData("annualLeaves", updatedPolicies);
+  };
+
+  const updateAnnualLeave = (
+    index: number,
+    field: keyof AnnualLeavePolicy,
+    value: string | number
+  ): void => {
+    const currentPolicies = formData.annualLeaves || [];
+    const updatedPolicies = currentPolicies.map((policy, i) =>
+      i === index ? { ...policy, [field]: value } : policy
+    );
+    updateFormData("annualLeaves", updatedPolicies);
   };
 
   return (
@@ -178,6 +222,133 @@ export function SelectWorkForm({
               </SelectContent>
             </Select>
           </div>
+        </div>
+      </div>
+
+      {/* 연차 정책 설정 */}
+      <div className="space-y-4 bg-white/50 backdrop-blur-sm p-4 rounded-lg border border-gray-200/50">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            연차 설정
+          </label>
+          {(formData.annualLeaves || []).map((policy, index) => (
+            <div
+              key={policy.id || index}
+              className="grid grid-cols-10 gap-2 mb-3 p-3 bg-gray-50 rounded-lg"
+            >
+              {/* 최소 근무년수 */}
+              <div className="col-span-3">
+                <label className="block text-xs text-gray-600 mb-1">
+                  최소 년수
+                </label>
+                <Input
+                  type="number"
+                  value={policy.minYears}
+                  onChange={(e) =>
+                    updateAnnualLeave(
+                      index,
+                      "minYears",
+                      parseInt(e.target.value) || 0
+                    )
+                  }
+                  min="0"
+                  className="text-sm"
+                />
+              </div>
+
+              {/* 최대 근무년수 */}
+              <div className="col-span-3">
+                <label className="block text-xs text-gray-600 mb-1">
+                  최대 년수
+                </label>
+                <Input
+                  type="number"
+                  value={policy.maxYears}
+                  onChange={(e) =>
+                    updateAnnualLeave(
+                      index,
+                      "maxYears",
+                      parseInt(e.target.value) || 0
+                    )
+                  }
+                  min="0"
+                  className="text-sm"
+                />
+              </div>
+
+              {/* 연차 일수 */}
+              <div className="col-span-2">
+                <label className="block text-xs text-gray-600 mb-1">
+                  연차 일수
+                </label>
+                <Input
+                  type="number"
+                  value={policy.leaveDays}
+                  onChange={(e) =>
+                    updateAnnualLeave(
+                      index,
+                      "leaveDays",
+                      parseInt(e.target.value) || 0
+                    )
+                  }
+                  min="0"
+                  max="365"
+                  className="text-sm"
+                />
+              </div>
+
+              {/* 휴일 일수 */}
+              <div className="col-span-1">
+                <label className="block text-xs text-gray-600 mb-1">휴일</label>
+                <Input
+                  type="number"
+                  value={policy.holidayDays}
+                  onChange={(e) =>
+                    updateAnnualLeave(
+                      index,
+                      "holidayDays",
+                      parseInt(e.target.value) || 0
+                    )
+                  }
+                  min="0"
+                  className="text-sm"
+                />
+              </div>
+
+              {/* 삭제 버튼 */}
+              <div className="col-span-1 flex items-end">
+                {(formData.annualLeaves || []).length > 1 && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => removeAnnualLeave(index)}
+                    className="text-red-500 hover:text-red-700 px-2"
+                  >
+                    ×
+                  </Button>
+                )}
+              </div>
+
+              {/* 표시 텍스트 */}
+              <div className="col-span-10 mt-2">
+                <p className="text-xs text-gray-600">
+                  근무 {policy.minYears}년 ~ {policy.maxYears}년: 연차{" "}
+                  {policy.leaveDays}일
+                  {policy.holidayDays > 0 && `, 휴일 ${policy.holidayDays}일`}
+                </p>
+              </div>
+            </div>
+          ))}
+
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={addAnnualLeave}
+            className="flex items-center gap-2 mt-2"
+          >
+            <Plus className="w-4 h-4" />
+            연차 정책 추가
+          </Button>
         </div>
       </div>
     </div>

--- a/app/settings/workpolicies/components/ShiftWorkForm.tsx
+++ b/app/settings/workpolicies/components/ShiftWorkForm.tsx
@@ -10,12 +10,23 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
-import { Calendar } from "lucide-react";
+import { Calendar, Plus } from "lucide-react";
+import { AnnualLeaveRequestDto } from "@/lib/services/attendance";
 
 // Type definitions
+interface AnnualLeavePolicy {
+  id?: string;
+  name: string;
+  minYears: number;
+  maxYears: number;
+  leaveDays: number;
+  holidayDays: number;
+}
+
 interface FormData {
   [key: string]: any;
   workName?: string;
+  annualLeaves?: AnnualLeavePolicy[];
   workingDaysPerWeek?: string;
   weeklyHoliday?: Record<string, boolean>;
   workHours?: string;
@@ -46,6 +57,39 @@ export function ShiftWorkForm({
 }: ShiftWorkFormProps): JSX.Element {
   const updateFormData = (field: string, value: any): void => {
     setFormData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  // 연차 정책 관리 함수들
+  const addAnnualLeave = (): void => {
+    const newPolicy: AnnualLeavePolicy = {
+      id: Date.now().toString(),
+      name: `정책 ${(formData.annualLeaves || []).length + 1}`,
+      minYears: 0,
+      maxYears: 1,
+      leaveDays: 15,
+      holidayDays: 0,
+    };
+
+    const currentPolicies = formData.annualLeaves || [];
+    updateFormData("annualLeaves", [...currentPolicies, newPolicy]);
+  };
+
+  const removeAnnualLeave = (index: number): void => {
+    const currentPolicies = formData.annualLeaves || [];
+    const updatedPolicies = currentPolicies.filter((_, i) => i !== index);
+    updateFormData("annualLeaves", updatedPolicies);
+  };
+
+  const updateAnnualLeave = (
+    index: number,
+    field: keyof AnnualLeavePolicy,
+    value: string | number
+  ): void => {
+    const currentPolicies = formData.annualLeaves || [];
+    const updatedPolicies = currentPolicies.map((policy, i) =>
+      i === index ? { ...policy, [field]: value } : policy
+    );
+    updateFormData("annualLeaves", updatedPolicies);
   };
 
   const weekDays: WeekDay[] = [
@@ -234,6 +278,133 @@ export function ShiftWorkForm({
             />
           </div>
           <span className="text-sm text-gray-600">분</span>
+        </div>
+      </div>
+
+      {/* 연차 정책 설정 */}
+      <div className="space-y-4 bg-white/50 backdrop-blur-sm p-4 rounded-lg border border-gray-200/50">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            연차 설정
+          </label>
+          {(formData.annualLeaves || []).map((policy, index) => (
+            <div
+              key={policy.id || index}
+              className="grid grid-cols-10 gap-2 mb-3 p-3 bg-gray-50 rounded-lg"
+            >
+              {/* 최소 근무년수 */}
+              <div className="col-span-3">
+                <label className="block text-xs text-gray-600 mb-1">
+                  최소 년수
+                </label>
+                <Input
+                  type="number"
+                  value={policy.minYears}
+                  onChange={(e) =>
+                    updateAnnualLeave(
+                      index,
+                      "minYears",
+                      parseInt(e.target.value) || 0
+                    )
+                  }
+                  min="0"
+                  className="text-sm"
+                />
+              </div>
+
+              {/* 최대 근무년수 */}
+              <div className="col-span-3">
+                <label className="block text-xs text-gray-600 mb-1">
+                  최대 년수
+                </label>
+                <Input
+                  type="number"
+                  value={policy.maxYears}
+                  onChange={(e) =>
+                    updateAnnualLeave(
+                      index,
+                      "maxYears",
+                      parseInt(e.target.value) || 0
+                    )
+                  }
+                  min="0"
+                  className="text-sm"
+                />
+              </div>
+
+              {/* 연차 일수 */}
+              <div className="col-span-2">
+                <label className="block text-xs text-gray-600 mb-1">
+                  연차 일수
+                </label>
+                <Input
+                  type="number"
+                  value={policy.leaveDays}
+                  onChange={(e) =>
+                    updateAnnualLeave(
+                      index,
+                      "leaveDays",
+                      parseInt(e.target.value) || 0
+                    )
+                  }
+                  min="0"
+                  max="365"
+                  className="text-sm"
+                />
+              </div>
+
+              {/* 휴일 일수 */}
+              <div className="col-span-1">
+                <label className="block text-xs text-gray-600 mb-1">휴일</label>
+                <Input
+                  type="number"
+                  value={policy.holidayDays}
+                  onChange={(e) =>
+                    updateAnnualLeave(
+                      index,
+                      "holidayDays",
+                      parseInt(e.target.value) || 0
+                    )
+                  }
+                  min="0"
+                  className="text-sm"
+                />
+              </div>
+
+              {/* 삭제 버튼 */}
+              <div className="col-span-1 flex items-end">
+                {(formData.annualLeaves || []).length > 1 && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => removeAnnualLeave(index)}
+                    className="text-red-500 hover:text-red-700 px-2"
+                  >
+                    ×
+                  </Button>
+                )}
+              </div>
+
+              {/* 표시 텍스트 */}
+              <div className="col-span-10 mt-2">
+                <p className="text-xs text-gray-600">
+                  근무 {policy.minYears}년 ~ {policy.maxYears}년: 연차{" "}
+                  {policy.leaveDays}일
+                  {policy.holidayDays > 0 && `, 휴일 ${policy.holidayDays}일`}
+                </p>
+              </div>
+            </div>
+          ))}
+
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={addAnnualLeave}
+            className="flex items-center gap-2 mt-2"
+          >
+            <Plus className="w-4 h-4" />
+            연차 정책 추가
+          </Button>
         </div>
       </div>
     </div>

--- a/app/settings/workpolicies/components/TimeWorkForm.tsx
+++ b/app/settings/workpolicies/components/TimeWorkForm.tsx
@@ -12,11 +12,22 @@ import {
 import { Button } from "@/components/ui/button";
 import { Calendar, Plus } from "lucide-react";
 import SelectTime from "@/components/clock/SelectTime";
+import { AnnualLeaveRequestDto } from "@/lib/services/attendance";
 
 // Type definitions
+interface AnnualLeavePolicy {
+  id?: string;
+  name: string;
+  minYears: number;
+  maxYears: number;
+  leaveDays: number;
+  holidayDays: number;
+}
+
 interface FormData {
   [key: string]: any;
   workName?: string;
+  annualLeaves?: AnnualLeavePolicy[];
   workingDays?: Record<string, boolean>;
   weeklyHoliday?: Record<string, boolean>;
   cycleStartDay?: string;
@@ -40,10 +51,10 @@ interface TimePickerState {
 }
 
 interface TimePickerRefs {
-  startTimeStart: React.RefObject<HTMLDivElement>;
-  startTimeEnd: React.RefObject<HTMLDivElement>;
-  breakTimeStart: React.RefObject<HTMLDivElement>;
-  breakTimeEnd: React.RefObject<HTMLDivElement>;
+  startTimeStart: React.RefObject<HTMLDivElement | null>;
+  startTimeEnd: React.RefObject<HTMLDivElement | null>;
+  breakTimeStart: React.RefObject<HTMLDivElement | null>;
+  breakTimeEnd: React.RefObject<HTMLDivElement | null>;
 }
 
 interface WeekDay {
@@ -90,6 +101,39 @@ export function TimeWorkForm({
 
   const closeTimePicker = (field: keyof TimePickerState): void => {
     setShowTimePicker((prev) => ({ ...prev, [field]: false }));
+  };
+
+  // 연차 정책 관리 함수들
+  const addAnnualLeave = (): void => {
+    const newPolicy: AnnualLeavePolicy = {
+      id: Date.now().toString(),
+      name: `정책 ${(formData.annualLeaves || []).length + 1}`,
+      minYears: 0,
+      maxYears: 1,
+      leaveDays: 15,
+      holidayDays: 0,
+    };
+
+    const currentPolicies = formData.annualLeaves || [];
+    updateFormData("annualLeaves", [...currentPolicies, newPolicy]);
+  };
+
+  const removeAnnualLeave = (index: number): void => {
+    const currentPolicies = formData.annualLeaves || [];
+    const updatedPolicies = currentPolicies.filter((_, i) => i !== index);
+    updateFormData("annualLeaves", updatedPolicies);
+  };
+
+  const updateAnnualLeave = (
+    index: number,
+    field: keyof AnnualLeavePolicy,
+    value: string | number
+  ): void => {
+    const currentPolicies = formData.annualLeaves || [];
+    const updatedPolicies = currentPolicies.map((policy, i) =>
+      i === index ? { ...policy, [field]: value } : policy
+    );
+    updateFormData("annualLeaves", updatedPolicies);
   };
 
   // 바깥 클릭 감지
@@ -448,6 +492,133 @@ export function TimeWorkForm({
           >
             <Plus className="w-4 h-4" />
             추가하기
+          </Button>
+        </div>
+      </div>
+
+      {/* 연차 정책 설정 */}
+      <div className="space-y-4 bg-white/50 backdrop-blur-sm p-4 rounded-lg border border-gray-200/50">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            연차 설정
+          </label>
+          {(formData.annualLeaves || []).map((policy, index) => (
+            <div
+              key={policy.id || index}
+              className="grid grid-cols-10 gap-2 mb-3 p-3 bg-gray-50 rounded-lg"
+            >
+              {/* 최소 근무년수 */}
+              <div className="col-span-3">
+                <label className="block text-xs text-gray-600 mb-1">
+                  최소 년수
+                </label>
+                <Input
+                  type="number"
+                  value={policy.minYears}
+                  onChange={(e) =>
+                    updateAnnualLeave(
+                      index,
+                      "minYears",
+                      parseInt(e.target.value) || 0
+                    )
+                  }
+                  min="0"
+                  className="text-sm"
+                />
+              </div>
+
+              {/* 최대 근무년수 */}
+              <div className="col-span-3">
+                <label className="block text-xs text-gray-600 mb-1">
+                  최대 년수
+                </label>
+                <Input
+                  type="number"
+                  value={policy.maxYears}
+                  onChange={(e) =>
+                    updateAnnualLeave(
+                      index,
+                      "maxYears",
+                      parseInt(e.target.value) || 0
+                    )
+                  }
+                  min="0"
+                  className="text-sm"
+                />
+              </div>
+
+              {/* 연차 일수 */}
+              <div className="col-span-2">
+                <label className="block text-xs text-gray-600 mb-1">
+                  연차 일수
+                </label>
+                <Input
+                  type="number"
+                  value={policy.leaveDays}
+                  onChange={(e) =>
+                    updateAnnualLeave(
+                      index,
+                      "leaveDays",
+                      parseInt(e.target.value) || 0
+                    )
+                  }
+                  min="0"
+                  max="365"
+                  className="text-sm"
+                />
+              </div>
+
+              {/* 휴일 일수 */}
+              <div className="col-span-1">
+                <label className="block text-xs text-gray-600 mb-1">휴일</label>
+                <Input
+                  type="number"
+                  value={policy.holidayDays}
+                  onChange={(e) =>
+                    updateAnnualLeave(
+                      index,
+                      "holidayDays",
+                      parseInt(e.target.value) || 0
+                    )
+                  }
+                  min="0"
+                  className="text-sm"
+                />
+              </div>
+
+              {/* 삭제 버튼 */}
+              <div className="col-span-1 flex items-end">
+                {(formData.annualLeaves || []).length > 1 && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => removeAnnualLeave(index)}
+                    className="text-red-500 hover:text-red-700 px-2"
+                  >
+                    ×
+                  </Button>
+                )}
+              </div>
+
+              {/* 표시 텍스트 */}
+              <div className="col-span-10 mt-2">
+                <p className="text-xs text-gray-600">
+                  근무 {policy.minYears}년 ~ {policy.maxYears}년: 연차{" "}
+                  {policy.leaveDays}일
+                  {policy.holidayDays > 0 && `, 휴일 ${policy.holidayDays}일`}
+                </p>
+              </div>
+            </div>
+          ))}
+
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={addAnnualLeave}
+            className="flex items-center gap-2 mt-2"
+          >
+            <Plus className="w-4 h-4" />
+            연차 정책 추가
           </Button>
         </div>
       </div>

--- a/app/settings/workpolicies/create/page.tsx
+++ b/app/settings/workpolicies/create/page.tsx
@@ -17,13 +17,24 @@ import {
   DayOfWeek,
   WorkCycle,
   WorkPolicyType,
+  AnnualLeaveRequestDto,
 } from "@/lib/services/attendance";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 
 // Type definitions
+interface AnnualLeavePolicy {
+  id?: string;
+  name: string;
+  minYears: number;
+  maxYears: number;
+  leaveDays: number;
+  holidayDays: number;
+}
+
 interface FormData {
   [key: string]: any;
+  annualLeaves?: AnnualLeavePolicy[];
 }
 
 interface PolicyData {
@@ -33,7 +44,18 @@ interface PolicyData {
 
 export default function CreateWorkPolicyPage(): JSX.Element {
   const [workType, setWorkType] = useState<string>("fixed");
-  const [formData, setFormData] = useState<FormData>({});
+  const [formData, setFormData] = useState<FormData>({
+    annualLeaves: [
+      {
+        id: "1",
+        name: "정책 1",
+        minYears: 0,
+        maxYears: 2,
+        leaveDays: 15,
+        holidayDays: 0,
+      },
+    ],
+  });
   const router = useRouter();
 
   // 근무 유형별 폼 컴포넌트 렌더링
@@ -166,7 +188,7 @@ export default function CreateWorkPolicyPage(): JSX.Element {
         breakEndTime, // string "HH:mm:ss"
         avgWorkTime: undefined,
         totalRequiredMinutes,
-        annualLeaves: undefined,
+        annualLeaves: policyData.annualLeaves || [],
       };
 
       const created = await workPolicyApi.createWorkPolicy(request as any);

--- a/app/vacation/page.tsx
+++ b/app/vacation/page.tsx
@@ -1,554 +1,527 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import React from "react";
 import {
-  Bell,
-  User,
   Calendar,
-  Users,
-  Settings,
-  FileText,
-  Megaphone,
-  ClipboardList,
-  Briefcase,
-  Home,
-  Plus,
-  CalendarDays,
   Gift,
   Star,
-  X,
-  CheckCircle,
+  Plus,
+  FileText,
   Clock,
+  CheckCircle,
+  XCircle,
+  AlertCircle,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
 import { MainLayout } from "@/components/layout/main-layout";
-import { GlassCard } from "@/components/ui/glass-card";
-import { GradientButton } from "@/components/ui/gradient-button";
-import { colors, typography } from "@/lib/design-tokens";
-import VacationModal from "./vacationmodal";
 import StyledPaging from "@/components/paging/styled-paging";
-import CalendarComponent from "./components/calendar";
-import { format } from "date-fns";
+import { leaveApi } from "@/lib/services/attendance/api";
+import {
+  CreateLeaveRequestDto,
+  LeaveType,
+} from "@/lib/services/attendance/types";
+import { useAuth } from "@/hooks/use-auth";
+import VacationModal from "./vacationmodal";
 
 // Type definitions
-interface Period {
-  value: string;
-  label: string;
-  months: number[];
-}
-
 interface VacationRecord {
   id: number;
   type: string;
   startDate: string;
-  endDate: string;
+  endDate?: string;
   days: number;
   reason: string;
-  status: string;
-  statusColor: string;
+  status: "승인됨" | "대기중" | "반려됨";
 }
 
-interface VacationType {
-  value: string;
-  label: string;
-  icon: React.ReactNode;
-  description: string;
+interface VacationStats {
+  totalDays: number;
+  usedDays: number;
+  remainingDays: number;
+  specialDays: number;
 }
 
 export default function VacationPage(): JSX.Element {
-  const [selectedPeriod, setSelectedPeriod] =
-    useState<string>("2025.10~2025.12");
+  const { user } = useAuth();
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [vacationRecords, setVacationRecords] = useState<VacationRecord[]>([]);
+  const [currentPage, setCurrentPage] = useState<number>(1);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const [selectedVacationType, setSelectedVacationType] =
     useState<string>("기본 연차");
-  const [startDate, setStartDate] = useState<string>("");
-  const [endDate, setEndDate] = useState<string>("");
-  const [currentPage, setCurrentPage] = useState<number>(1);
-  const [isCalendarOpen, setIsCalendarOpen] = useState<boolean>(false);
-  const calendarRef = useRef<HTMLDivElement>(null);
-
-  // 1년을 3개월씩 나눈 기간들
-  const periods: Period[] = [
-    {
-      value: "2025.10~2025.12",
-      label: "2025.10~2025.12",
-      months: [10, 11, 12],
-    },
-    { value: "2025.07~2025.09", label: "2025.07~2025.09", months: [7, 8, 9] },
-    { value: "2025.04~2025.06", label: "2025.04~2025.06", months: [4, 5, 6] },
-    { value: "2025.01~2025.03", label: "2025.01~2025.03", months: [1, 2, 3] },
-  ];
-
-  // 더미 데이터 - 실제로는 props나 API에서 받아올 데이터
-  const vacationRecords: VacationRecord[] = [
-    {
-      id: 1,
-      type: "연차",
-      startDate: "2025.08.01",
-      endDate: "2025.08.01",
-      days: 1,
-      reason: "[2025-08-01] 연차 사용 신청합니다.",
-      status: "승인됨",
-      statusColor:
-        colors.status.info.bg +
-        " " +
-        colors.status.info.text +
-        " " +
-        colors.status.info.border,
-    },
-    {
-      id: 2,
-      type: "연차",
-      startDate: "2025.08.05",
-      endDate: "2025.08.05",
-      days: 1,
-      reason: "[2025-08-05] 개인 사정으로 인한 연차 신청",
-      status: "대기중",
-      statusColor:
-        colors.status.warning.bg +
-        " " +
-        colors.status.warning.text +
-        " " +
-        colors.status.warning.border,
-    },
-    {
-      id: 3,
-      type: "연차",
-      startDate: "2025.07.28",
-      endDate: "2025.07.28",
-      days: 1,
-      reason: "[2025-07-28] 병원 진료로 인한 연차 신청",
-      status: "승인됨",
-      statusColor:
-        colors.status.info.bg +
-        " " +
-        colors.status.info.text +
-        " " +
-        colors.status.info.border,
-    },
-    {
-      id: 4,
-      type: "연차",
-      startDate: "2025.07.15",
-      endDate: "2025.07.16",
-      days: 2,
-      reason: "[2025-07-15] 여행 계획으로 인한 연차 신청",
-      status: "반려됨",
-      statusColor:
-        colors.status.error.bg +
-        " " +
-        colors.status.error.text +
-        " " +
-        colors.status.error.border,
-    },
-    {
-      id: 5,
-      type: "반차",
-      startDate: "2025.07.10",
-      endDate: "오후",
-      days: 0.5,
-      reason: "[2025-07-10] 오후 개인 업무 처리",
-      status: "승인됨",
-      statusColor:
-        colors.status.info.bg +
-        " " +
-        colors.status.info.text +
-        " " +
-        colors.status.info.border,
-    },
-    {
-      id: 6,
-      type: "연차",
-      startDate: "2025.07.03",
-      endDate: "2025.07.03",
-      days: 1,
-      reason: "[2025-07-03] 가족 행사 참석",
-      status: "승인됨",
-      statusColor:
-        colors.status.info.bg +
-        " " +
-        colors.status.info.text +
-        " " +
-        colors.status.info.border,
-    },
-    {
-      id: 7,
-      type: "연차",
-      startDate: "2025.06.15",
-      endDate: "2025.06.16",
-      days: 2,
-      reason: "[2025-06-15] 가족 여행",
-      status: "승인됨",
-      statusColor:
-        colors.status.info.bg +
-        " " +
-        colors.status.info.text +
-        " " +
-        colors.status.info.border,
-    },
-    {
-      id: 8,
-      type: "반차",
-      startDate: "2025.06.10",
-      endDate: "오전",
-      days: 0.5,
-      reason: "[2025-06-10] 오전 개인 업무",
-      status: "승인됨",
-      statusColor:
-        colors.status.info.bg +
-        " " +
-        colors.status.info.text +
-        " " +
-        colors.status.info.border,
-    },
-    {
-      id: 9,
-      type: "연차",
-      startDate: "2025.05.20",
-      endDate: "2025.05.20",
-      days: 1,
-      reason: "[2025-05-20] 병원 진료",
-      status: "승인됨",
-      statusColor:
-        colors.status.info.bg +
-        " " +
-        colors.status.info.text +
-        " " +
-        colors.status.info.border,
-    },
-    {
-      id: 10,
-      type: "연차",
-      startDate: "2025.05.10",
-      endDate: "2025.05.10",
-      days: 1,
-      reason: "[2025-05-10] 개인 사정",
-      status: "승인됨",
-      statusColor:
-        colors.status.info.bg +
-        " " +
-        colors.status.info.text +
-        " " +
-        colors.status.info.border,
-    },
-  ];
-
-  // 휴가 유형 데이터
-  const vacationTypes: VacationType[] = [
-    {
-      value: "기본 연차",
-      label: "기본 연차",
-      icon: <CalendarDays className="w-5 h-5" />,
-      description: "연간 15일 기본 연차",
-    },
-    {
-      value: "반차",
-      label: "반차",
-      icon: <Clock className="w-5 h-5" />,
-      description: "오전/오후 반차",
-    },
-    {
-      value: "병가",
-      label: "병가",
-      icon: <User className="w-5 h-5" />,
-      description: "질병으로 인한 휴가",
-    },
-    {
-      value: "공가",
-      label: "공가",
-      icon: <FileText className="w-5 h-5" />,
-      description: "공무로 인한 휴가",
-    },
-    {
-      value: "특별 휴가",
-      label: "특별 휴가",
-      icon: <Gift className="w-5 h-5" />,
-      description: "특별한 경우의 휴가",
-    },
-  ];
+  const [stats, setStats] = useState<VacationStats>({
+    totalDays: 15,
+    usedDays: 12,
+    remainingDays: 3,
+    specialDays: 1,
+  });
 
   // 페이지네이션 설정
   const itemsPerPage = 5;
-  const totalPages = Math.ceil(vacationRecords.length / itemsPerPage);
+  const totalItems = vacationRecords.length;
   const startIndex = (currentPage - 1) * itemsPerPage;
   const endIndex = startIndex + itemsPerPage;
   const currentRecords = vacationRecords.slice(startIndex, endIndex);
 
-  // 통계 계산
-  const totalVacationDays = vacationRecords.reduce(
-    (sum, record) => sum + record.days,
-    0
-  );
-  const approvedVacations = vacationRecords.filter(
-    (record) => record.status === "승인됨"
-  );
-  const pendingVacations = vacationRecords.filter(
-    (record) => record.status === "대기중"
-  );
-  const rejectedVacations = vacationRecords.filter(
-    (record) => record.status === "반려됨"
-  );
+  // 샘플 데이터 - 페이지네이션 테스트를 위해 더 많은 데이터 추가
+  useEffect(() => {
+    setVacationRecords([
+      {
+        id: 1,
+        type: "연차",
+        startDate: "2025.08.01",
+        days: 1,
+        reason: "[2025-08-01] 연차 사용 신청합니다.",
+        status: "승인됨",
+      },
+      {
+        id: 2,
+        type: "연차",
+        startDate: "2025.08.05",
+        days: 1,
+        reason: "[2025-08-05] 개인 사정으로 인한 연차 신청",
+        status: "대기중",
+      },
+      {
+        id: 3,
+        type: "연차",
+        startDate: "2025.07.28",
+        days: 1,
+        reason: "[2025-07-28] 병원 진료로 인한 연차 신청",
+        status: "승인됨",
+      },
+      {
+        id: 4,
+        type: "연차",
+        startDate: "2025.07.15",
+        endDate: "2025.07.16",
+        days: 2,
+        reason: "[2025-07-15] 여행 계획으로 인한 연차 신청",
+        status: "반려됨",
+      },
+      {
+        id: 5,
+        type: "반차",
+        startDate: "2025.07.10",
+        endDate: "오후",
+        days: 0.5,
+        reason: "[2025-07-10] 오후 개인 업무 처리",
+        status: "승인됨",
+      },
+      {
+        id: 6,
+        type: "연차",
+        startDate: "2025.07.03",
+        days: 1,
+        reason: "[2025-07-03] 가족 행사 참석",
+        status: "승인됨",
+      },
+      {
+        id: 7,
+        type: "연차",
+        startDate: "2025.06.20",
+        days: 1,
+        reason: "[2025-06-20] 개인 사정으로 인한 휴가",
+        status: "승인됨",
+      },
+      {
+        id: 8,
+        type: "반차",
+        startDate: "2025.06.15",
+        endDate: "오전",
+        days: 0.5,
+        reason: "[2025-06-15] 오전 병원 진료",
+        status: "승인됨",
+      },
+      {
+        id: 9,
+        type: "연차",
+        startDate: "2025.06.10",
+        endDate: "2025.06.12",
+        days: 3,
+        reason: "[2025-06-10] 가족 여행으로 인한 연차 신청",
+        status: "승인됨",
+      },
+      {
+        id: 10,
+        type: "연차",
+        startDate: "2025.05.25",
+        days: 1,
+        reason: "[2025-05-25] 개인 업무 처리",
+        status: "대기중",
+      },
+      {
+        id: 11,
+        type: "연차",
+        startDate: "2025.05.18",
+        days: 1,
+        reason: "[2025-05-18] 결혼식 참석",
+        status: "승인됨",
+      },
+      {
+        id: 12,
+        type: "반차",
+        startDate: "2025.05.10",
+        endDate: "오후",
+        days: 0.5,
+        reason: "[2025-05-10] 오후 개인 일정",
+        status: "반려됨",
+      },
+    ]);
+  }, []);
 
-  const handlePeriodChange = (value: string): void => {
-    setSelectedPeriod(value);
+  const getStatusBadge = (status: string) => {
+    switch (status) {
+      case "승인됨":
+        return (
+          <Badge
+            variant="outline"
+            className="text-blue-600 border-blue-200 bg-blue-50"
+          >
+            {status}
+          </Badge>
+        );
+      case "대기중":
+        return (
+          <Badge
+            variant="outline"
+            className="text-orange-600 border-orange-200 bg-orange-50"
+          >
+            {status}
+          </Badge>
+        );
+      case "반려됨":
+        return (
+          <Badge
+            variant="outline"
+            className="text-red-600 border-red-200 bg-red-50"
+          >
+            {status}
+          </Badge>
+        );
+      default:
+        return <Badge variant="outline">{status}</Badge>;
+    }
   };
 
-  const handleVacationTypeChange = (value: string): void => {
-    setSelectedVacationType(value);
+  const formatDateRange = (
+    startDate: string,
+    days: number,
+    endDate?: string
+  ) => {
+    if (days === 0.5) {
+      return `${startDate} ~ ${endDate}`;
+    }
+    if (endDate && endDate !== startDate) {
+      return `${startDate} ~ ${endDate}`;
+    }
+    return startDate;
   };
 
-  const handlePageChange = (page: number): void => {
-    setCurrentPage(page);
+  const handlePageChange = (pageNumber: number) => {
+    setCurrentPage(pageNumber);
   };
 
-  const handleOpenModal = (): void => {
+  // 휴가 카드 클릭 핸들러
+  const handleVacationCardClick = (vacationType: string) => {
+    setSelectedVacationType(vacationType);
     setIsModalOpen(true);
   };
 
-  const handleCloseModal = (): void => {
-    setIsModalOpen(false);
+  // 휴가 타입을 LeaveType enum으로 변환
+  const getLeaveType = (vacationType: string): LeaveType => {
+    switch (vacationType) {
+      case "기본 연차":
+      case "연차":
+        return LeaveType.BASIC_ANNUAL;
+      case "보상 연차":
+        return LeaveType.COMPENSATION_ANNUAL;
+      case "특별 연차":
+        return LeaveType.SPECIAL_ANNUAL;
+      default:
+        return LeaveType.BASIC_ANNUAL;
+    }
   };
 
-  const handleCalendarToggle = (): void => {
-    setIsCalendarOpen(!isCalendarOpen);
-  };
+  // 휴가 신청 처리
+  const handleVacationSubmit = async (data: any) => {
+    if (!user?.id) {
+      alert("로그인이 필요합니다.");
+      return;
+    }
 
-  const handleDateSelect = (date: Date): void => {
-    const formattedDate = format(date, "yyyy.MM.dd");
-    if (!startDate) {
-      setStartDate(formattedDate);
-    } else if (!endDate) {
-      setEndDate(formattedDate);
-    } else {
-      setStartDate(formattedDate);
-      setEndDate("");
+    setIsSubmitting(true);
+
+    try {
+      // VacationModal의 데이터를 API 요청 형식으로 변환
+      const leaveRequest: CreateLeaveRequestDto = {
+        employeeId: user.id,
+        leaveType: getLeaveType(data.type),
+        startDate: data.dates[0] || data.startDate, // dates 배열의 첫 번째 값 또는 startDate 사용
+        endDate:
+          data.dates[1] || data.dates[0] || data.endDate || data.startDate, // 종료일이 없으면 시작일과 동일
+        reason: data.reason,
+        // 반차인 경우 시간 정보 포함
+        ...(data.type === "반차" &&
+          data.startTime &&
+          data.endTime && {
+            startTime: {
+              hour: parseInt(data.startTime.split(":")[0]),
+              minute: parseInt(data.startTime.split(":")[1]),
+              second: 0,
+              nano: 0,
+            },
+            endTime: {
+              hour: parseInt(data.endTime.split(":")[0]),
+              minute: parseInt(data.endTime.split(":")[1]),
+              second: 0,
+              nano: 0,
+            },
+          }),
+      };
+
+      console.log("휴가 신청 요청 데이터:", leaveRequest);
+
+      const response = await leaveApi.createLeaveRequest(leaveRequest);
+
+      console.log("휴가 신청 성공:", response);
+
+      // 성공 시 새로운 기록을 목록에 추가
+      const newRecord: VacationRecord = {
+        id: response.requestId,
+        type: data.type,
+        startDate: response.startDate,
+        endDate:
+          response.endDate !== response.startDate
+            ? response.endDate
+            : undefined,
+        days: response.totalDays,
+        reason: response.reason,
+        status:
+          response.status === "PENDING"
+            ? "대기중"
+            : response.status === "APPROVED"
+            ? "승인됨"
+            : response.status === "REJECTED"
+            ? "반려됨"
+            : "대기중",
+      };
+
+      setVacationRecords((prev) => [newRecord, ...prev]);
+      setIsModalOpen(false);
+      alert("휴가 신청이 성공적으로 제출되었습니다.");
+    } catch (error: any) {
+      console.error("휴가 신청 실패:", error);
+
+      let errorMessage = "휴가 신청 중 오류가 발생했습니다.";
+
+      if (error?.response?.data?.message) {
+        errorMessage = error.response.data.message;
+      } else if (error?.message) {
+        errorMessage = error.message;
+      }
+
+      alert(errorMessage);
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
   return (
     <MainLayout>
-      {/* Header */}
-      <div className="mb-8">
-        <div className="flex items-center justify-between mb-4">
-          <div className="flex items-center gap-4">
-            <h1 className={`${typography.h1} text-gray-800`}>휴가 관리</h1>
-            <div className="flex items-center gap-2 text-gray-600">
-              <Calendar className="w-5 h-5" />
-              <span className="text-sm">연간 휴가 현황 및 신청</span>
-            </div>
+      <div className="space-y-6">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">휴가 등계</h1>
+            <p className="text-gray-600 mt-1">
+              나의 휴가 현황을 확인하고 관리하세요
+            </p>
           </div>
-          <GradientButton onClick={handleOpenModal}>
-            <Plus className="w-4 h-4 mr-2" />
-            휴가 신청
-          </GradientButton>
-        </div>
-        <p className="text-gray-600">
-          연차 사용 현황을 확인하고 새로운 휴가를 신청할 수 있습니다.
-        </p>
-      </div>
-
-      {/* Statistics Cards */}
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
-        <GlassCard className="p-6">
-          <div className="flex items-center gap-4">
-            <div className="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center">
-              <CalendarDays className="w-6 h-6 text-blue-600" />
-            </div>
-            <div>
-              <h3 className="text-sm font-semibold text-gray-800">
-                총 사용 일수
-              </h3>
-              <p className="text-2xl font-bold text-blue-600">
-                {totalVacationDays}일
-              </p>
-            </div>
-          </div>
-        </GlassCard>
-
-        <GlassCard className="p-6">
-          <div className="flex items-center gap-4">
-            <div className="w-12 h-12 bg-green-100 rounded-lg flex items-center justify-center">
-              <CheckCircle className="w-6 h-6 text-green-600" />
-            </div>
-            <div>
-              <h3 className="text-sm font-semibold text-gray-800">
-                승인된 휴가
-              </h3>
-              <p className="text-2xl font-bold text-green-600">
-                {approvedVacations.length}건
-              </p>
-            </div>
-          </div>
-        </GlassCard>
-
-        <GlassCard className="p-6">
-          <div className="flex items-center gap-4">
-            <div className="w-12 h-12 bg-yellow-100 rounded-lg flex items-center justify-center">
-              <Clock className="w-6 h-6 text-yellow-600" />
-            </div>
-            <div>
-              <h3 className="text-sm font-semibold text-gray-800">대기중</h3>
-              <p className="text-2xl font-bold text-yellow-600">
-                {pendingVacations.length}건
-              </p>
-            </div>
-          </div>
-        </GlassCard>
-
-        <GlassCard className="p-6">
-          <div className="flex items-center gap-4">
-            <div className="w-12 h-12 bg-red-100 rounded-lg flex items-center justify-center">
-              <X className="w-6 h-6 text-red-600" />
-            </div>
-            <div>
-              <h3 className="text-sm font-semibold text-gray-800">
-                반려된 휴가
-              </h3>
-              <p className="text-2xl font-bold text-red-600">
-                {rejectedVacations.length}건
-              </p>
-            </div>
-          </div>
-        </GlassCard>
-      </div>
-
-      {/* Filters */}
-      <div className="flex items-center gap-4 mb-6">
-        <div className="flex items-center gap-2">
-          <span className="text-sm font-medium text-gray-700">기간:</span>
-          <Select value={selectedPeriod} onValueChange={handlePeriodChange}>
-            <SelectTrigger className="w-48">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {periods.map((period) => (
-                <SelectItem key={period.value} value={period.value}>
-                  {period.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
         </div>
 
-        <div className="flex items-center gap-2">
-          <span className="text-sm font-medium text-gray-700">휴가 유형:</span>
-          <Select
-            value={selectedVacationType}
-            onValueChange={handleVacationTypeChange}
+        {/* Stats Cards */}
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+          <Card
+            className="bg-white border-0 shadow-sm hover:shadow-md transition-shadow cursor-pointer"
+            onClick={() => handleVacationCardClick("기본 연차")}
           >
-            <SelectTrigger className="w-48">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {vacationTypes.map((type) => (
-                <SelectItem key={type.value} value={type.value}>
-                  <div className="flex items-center gap-2">
-                    {type.icon}
-                    {type.label}
-                  </div>
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-      </div>
+            <CardContent className="p-6">
+              <div className="flex items-center space-x-4">
+                <div className="p-3 bg-blue-100 rounded-full">
+                  <Calendar className="w-6 h-6 text-blue-600" />
+                </div>
+                <div>
+                  <p className="text-sm text-gray-600">기본 연차</p>
+                  <p className="text-2xl font-bold text-gray-900">
+                    {stats.usedDays}
+                    <span className="text-sm font-normal text-gray-500">
+                      일 남음
+                    </span>
+                  </p>
+                  <p className="text-xs text-blue-600">3월 사용함</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
 
-      {/* Vacation Records Table */}
-      <GlassCard className="p-6">
-        <div className="overflow-x-auto">
-          <table className="w-full">
-            <thead>
-              <tr className="border-b border-gray-200">
-                <th className="text-left py-3 px-4 font-semibold text-gray-700">
-                  유형
-                </th>
-                <th className="text-left py-3 px-4 font-semibold text-gray-700">
-                  시작일
-                </th>
-                <th className="text-left py-3 px-4 font-semibold text-gray-700">
-                  종료일
-                </th>
-                <th className="text-left py-3 px-4 font-semibold text-gray-700">
-                  일수
-                </th>
-                <th className="text-left py-3 px-4 font-semibold text-gray-700">
-                  사유
-                </th>
-                <th className="text-left py-3 px-4 font-semibold text-gray-700">
-                  상태
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {currentRecords.map((record) => (
-                <tr
-                  key={record.id}
-                  className="border-b border-gray-100 hover:bg-gray-50"
+          <Card
+            className="bg-white border-0 shadow-sm hover:shadow-md transition-shadow cursor-pointer"
+            onClick={() => handleVacationCardClick("보상 연차")}
+          >
+            <CardContent className="p-6">
+              <div className="flex items-center space-x-4">
+                <div className="p-3 bg-green-100 rounded-full">
+                  <Gift className="w-6 h-6 text-green-600" />
+                </div>
+                <div>
+                  <p className="text-sm text-gray-600">보상 연차</p>
+                  <p className="text-2xl font-bold text-gray-900">
+                    4
+                    <span className="text-sm font-normal text-gray-500">
+                      일 남음
+                    </span>
+                  </p>
+                  <p className="text-xs text-green-600">1월 사용함</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card
+            className="bg-white border-0 shadow-sm hover:shadow-md transition-shadow cursor-pointer"
+            onClick={() => handleVacationCardClick("특별 연차")}
+          >
+            <CardContent className="p-6">
+              <div className="flex items-center space-x-4">
+                <div className="p-3 bg-yellow-100 rounded-full">
+                  <Star className="w-6 h-6 text-yellow-600" />
+                </div>
+                <div>
+                  <p className="text-sm text-gray-600">특별 연차</p>
+                  <p className="text-2xl font-bold text-gray-900">
+                    1
+                    <span className="text-sm font-normal text-gray-500">
+                      일 남음
+                    </span>
+                  </p>
+                  <p className="text-xs text-yellow-600">0월 사용함</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Vacation Records */}
+        <Card className="bg-white border-0 shadow-sm">
+          <CardHeader className="pb-4">
+            <div className="flex items-center justify-between">
+              <CardTitle className="text-lg font-semibold text-gray-900">
+                휴가 기록
+              </CardTitle>
+              <div className="flex items-center space-x-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="text-gray-600 border-gray-200"
                 >
-                  <td className="py-3 px-4">
-                    <span className="inline-flex items-center gap-2">
-                      {record.type === "연차" && (
-                        <CalendarDays className="w-4 h-4 text-blue-500" />
-                      )}
-                      {record.type === "반차" && (
-                        <Clock className="w-4 h-4 text-green-500" />
-                      )}
+                  <FileText className="w-4 h-4 mr-2" />
+                  날짜 범위 선택
+                </Button>
+                <Button
+                  onClick={() => {
+                    setSelectedVacationType("기본 연차");
+                    setIsModalOpen(true);
+                  }}
+                  className="bg-blue-600 hover:bg-blue-700 text-white"
+                  size="sm"
+                >
+                  <Plus className="w-4 h-4 mr-2" />
+                  휴가 신청
+                </Button>
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent className="p-0">
+            <Table>
+              <TableHeader>
+                <TableRow className="border-gray-100">
+                  <TableHead className="text-gray-600 font-medium">
+                    구분
+                  </TableHead>
+                  <TableHead className="text-gray-600 font-medium">
+                    기간
+                  </TableHead>
+                  <TableHead className="text-gray-600 font-medium">
+                    일수
+                  </TableHead>
+                  <TableHead className="text-gray-600 font-medium">
+                    사유
+                  </TableHead>
+                  <TableHead className="text-gray-600 font-medium">
+                    상태
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {currentRecords.map((record) => (
+                  <TableRow
+                    key={record.id}
+                    className="border-gray-100 hover:bg-gray-50"
+                  >
+                    <TableCell className="font-medium text-gray-900">
                       {record.type}
-                    </span>
-                  </td>
-                  <td className="py-3 px-4 text-gray-700">
-                    {record.startDate}
-                  </td>
-                  <td className="py-3 px-4 text-gray-700">{record.endDate}</td>
-                  <td className="py-3 px-4 text-gray-700">{record.days}일</td>
-                  <td className="py-3 px-4 text-gray-700 max-w-xs truncate">
-                    {record.reason}
-                  </td>
-                  <td className="py-3 px-4">
-                    <span
-                      className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium ${record.statusColor}`}
-                    >
-                      {record.status}
-                    </span>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+                    </TableCell>
+                    <TableCell className="text-gray-600">
+                      {formatDateRange(
+                        record.startDate,
+                        record.days,
+                        record.endDate
+                      )}
+                    </TableCell>
+                    <TableCell className="text-gray-600">
+                      {record.days}일
+                    </TableCell>
+                    <TableCell className="text-gray-600 max-w-md truncate">
+                      {record.reason}
+                    </TableCell>
+                    <TableCell>{getStatusBadge(record.status)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
 
-        {/* Pagination */}
-        <div className="mt-6 flex justify-center">
-          <StyledPaging
-            currentPage={currentPage}
-            totalPages={totalPages}
-            onPageChange={handlePageChange}
-          />
-        </div>
-      </GlassCard>
+          {/* Pagination */}
+          <div className="px-6 pb-6">
+            <StyledPaging
+              currentPage={currentPage}
+              totalItems={totalItems}
+              itemsPerPage={itemsPerPage}
+              onPageChange={handlePageChange}
+            />
+          </div>
+        </Card>
 
-      {/* Vacation Modal */}
-      {isModalOpen && (
+        {/* Vacation Modal */}
         <VacationModal
           isOpen={isModalOpen}
-          onClose={handleCloseModal}
-          vacationTypes={vacationTypes}
-          onCalendarToggle={handleCalendarToggle}
-          isCalendarOpen={isCalendarOpen}
-          startDate={startDate}
-          endDate={endDate}
-          onDateSelect={handleDateSelect}
+          onClose={() => setIsModalOpen(false)}
+          onSubmit={handleVacationSubmit}
+          defaultVacationType={selectedVacationType}
         />
-      )}
+      </div>
     </MainLayout>
   );
 }

--- a/app/vacation/vacationmodal.tsx
+++ b/app/vacation/vacationmodal.tsx
@@ -89,7 +89,7 @@ export default function VacationModal({
 
   const vacationTypes = propVacationTypes || defaultVacationTypes;
 
-  const handleStartDateChange = (newStartDate: Date): void => {
+  const handleStartDateChange = (newStartDate: Date | null): void => {
     setStartDate(newStartDate);
 
     // 시작일만 선택된 경우에도 해당 날짜를 selectedDates에 추가
@@ -102,7 +102,7 @@ export default function VacationModal({
     }
   };
 
-  const handleEndDateChange = (newEndDate: Date): void => {
+  const handleEndDateChange = (newEndDate: Date | null): void => {
     setEndDate(newEndDate);
 
     // 종료일만 선택된 경우에도 해당 날짜를 selectedDates에 추가
@@ -284,8 +284,9 @@ export default function VacationModal({
                 {showStartTimeDropdown && (
                   <div className="absolute top-full left-0 right-0 mt-1 bg-white border border-gray-200 rounded-lg shadow-lg z-10">
                     <SelectTime
-                      selectedTime={startTime}
                       onTimeSelect={handleStartTimeSelect}
+                      onClose={() => setShowStartTimeDropdown(false)}
+                      isDropdown={true}
                     />
                   </div>
                 )}
@@ -304,8 +305,9 @@ export default function VacationModal({
                 {showEndTimeDropdown && (
                   <div className="absolute top-full left-0 right-0 mt-1 bg-white border border-gray-200 rounded-lg shadow-lg z-10">
                     <SelectTime
-                      selectedTime={endTime}
                       onTimeSelect={handleEndTimeSelect}
+                      onClose={() => setShowEndTimeDropdown(false)}
+                      isDropdown={true}
                     />
                   </div>
                 )}

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,46 +1,35 @@
 import * as React from "react";
-import { Slot } from "@radix-ui/react-slot";
-import { cva, type VariantProps } from "class-variance-authority";
-
 import { cn } from "@/lib/utils";
 
-const badgeVariants = cva(
-  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
-  {
-    variants: {
-      variant: {
-        default:
-          "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
-        secondary:
-          "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
-        destructive:
-          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
-        outline:
-          "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-    },
+interface BadgeProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: "default" | "secondary" | "destructive" | "outline";
+}
+
+const Badge = React.forwardRef<HTMLDivElement, BadgeProps>(
+  ({ className, variant = "default", ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+          {
+            "border-transparent bg-primary text-primary-foreground hover:bg-primary/80":
+              variant === "default",
+            "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80":
+              variant === "secondary",
+            "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80":
+              variant === "destructive",
+            "border border-input bg-background hover:bg-accent hover:text-accent-foreground":
+              variant === "outline",
+          },
+          className
+        )}
+        {...props}
+      />
+    );
   }
 );
 
-function Badge({
-  className,
-  variant,
-  asChild = false,
-  ...props
-}: React.ComponentProps<"span"> &
-  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
-  const Comp = asChild ? Slot : "span";
+Badge.displayName = "Badge";
 
-  return (
-    <Comp
-      data-slot="badge"
-      className={cn(badgeVariants({ variant }), className)}
-      {...props}
-    />
-  );
-}
-
-export { Badge, badgeVariants };
+export { Badge };

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -1,108 +1,110 @@
-"use client"
+"use client";
 
-import * as React from "react"
+import * as React from "react";
+import { cn } from "@/lib/utils";
 
-import { cn } from "@/lib/utils"
-
-function Table({ className, ...props }: React.ComponentProps<"table">) {
-  return (
-    <div
-      data-slot="table-container"
-      className="relative w-full overflow-x-auto"
-    >
-      <table
-        data-slot="table"
-        className={cn("w-full caption-bottom text-sm", className)}
-        {...props}
-      />
-    </div>
-  )
-}
-
-function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
-  return (
-    <thead
-      data-slot="table-header"
-      className={cn("[&_tr]:border-b", className)}
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn("w-full caption-bottom text-sm", className)}
       {...props}
     />
-  )
-}
+  </div>
+));
+Table.displayName = "Table";
 
-function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
-  return (
-    <tbody
-      data-slot="table-body"
-      className={cn("[&_tr:last-child]:border-0", className)}
-      {...props}
-    />
-  )
-}
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+));
+TableHeader.displayName = "TableHeader";
 
-function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
-  return (
-    <tfoot
-      data-slot="table-footer"
-      className={cn(
-        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
-        className
-      )}
-      {...props}
-    />
-  )
-}
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
+));
+TableBody.displayName = "TableBody";
 
-function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
-  return (
-    <tr
-      data-slot="table-row"
-      className={cn(
-        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
-        className
-      )}
-      {...props}
-    />
-  )
-}
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn(
+      "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+      className
+    )}
+    {...props}
+  />
+));
+TableFooter.displayName = "TableFooter";
 
-function TableHead({ className, ...props }: React.ComponentProps<"th">) {
-  return (
-    <th
-      data-slot="table-head"
-      className={cn(
-        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
-        className
-      )}
-      {...props}
-    />
-  )
-}
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      className
+    )}
+    {...props}
+  />
+));
+TableRow.displayName = "TableRow";
 
-function TableCell({ className, ...props }: React.ComponentProps<"td">) {
-  return (
-    <td
-      data-slot="table-cell"
-      className={cn(
-        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
-        className
-      )}
-      {...props}
-    />
-  )
-}
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
+      className
+    )}
+    {...props}
+  />
+));
+TableHead.displayName = "TableHead";
 
-function TableCaption({
-  className,
-  ...props
-}: React.ComponentProps<"caption">) {
-  return (
-    <caption
-      data-slot="table-caption"
-      className={cn("text-muted-foreground mt-4 text-sm", className)}
-      {...props}
-    />
-  )
-}
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
+    {...props}
+  />
+));
+TableCell.displayName = "TableCell";
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn("mt-4 text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+TableCaption.displayName = "TableCaption";
 
 export {
   Table,
@@ -113,4 +115,4 @@ export {
   TableRow,
   TableCell,
   TableCaption,
-}
+};

--- a/lib/services/attendance/README.md
+++ b/lib/services/attendance/README.md
@@ -324,6 +324,40 @@ try {
 }
 ```
 
+## Employee Leave Balance API
+
+직원 연차 잔액 관리 관련 API들입니다.
+
+### 사용 예시
+
+```typescript
+import { employeeLeaveBalanceApi, LeaveType } from '@/lib/services/attendance'
+
+// 연차 자동 부여
+const grantedLeaves = await employeeLeaveBalanceApi.grantAnnualLeave(123, '2024-01-01')
+
+// 특정 타입 잔여 연차 조회
+const remainingDays = await employeeLeaveBalanceApi.getRemainingLeave(123, LeaveType.BASIC_ANNUAL)
+
+// 전체 잔여 연차 조회
+const totalRemaining = await employeeLeaveBalanceApi.getTotalRemainingLeave(123)
+
+// 연차 잔액 상세 조회
+const leaveBalances = await employeeLeaveBalanceApi.getLeaveBalances(123)
+
+// 연차 잔액 요약 조회
+const summary = await employeeLeaveBalanceApi.getLeaveBalanceSummary(123)
+
+// 연차 초기화 및 재부여
+const resetLeaves = await employeeLeaveBalanceApi.resetAndGrantAnnualLeave(123, '2024-01-01')
+
+// 연차 복구
+const restoreResult = await employeeLeaveBalanceApi.restoreLeave(123, LeaveType.BASIC_ANNUAL, 3)
+
+// 전체 직원 연차 초기화 (관리자 전용)
+const resetAllResult = await employeeLeaveBalanceApi.resetAllEmployeesAnnualLeave('2024-01-01')
+```
+
 ## 타입 안전성
 
 모든 API 함수는 TypeScript 타입을 제공하여 컴파일 타임에 타입 안전성을 보장합니다. IDE에서 자동완성과 타입 체크를 활용할 수 있습니다.

--- a/lib/services/attendance/api.ts
+++ b/lib/services/attendance/api.ts
@@ -20,10 +20,13 @@ import {
   UserWorkPolicyDto,
   ColleagueScheduleResponseDto,
   WeeklyWorkDetail,
+  EmployeeLeaveBalanceResponseDto,
+  EmployeeLeaveBalanceSummaryDto,
   ApiResult,
   // Enums
   AttendanceStatus,
   WorkStatus,
+  LeaveType,
 } from "./types";
 
 // Attendance API
@@ -429,6 +432,104 @@ export const workMonitorApi = {
   updateTodayWorkMonitorData: async (): Promise<WorkMonitorDto> => {
     const response = await apiClient.post<ApiResult<WorkMonitorDto>>(
       "/api/work-monitor/update/today"
+    );
+    return response.data.data;
+  },
+};
+
+// Employee Leave Balance API
+export const employeeLeaveBalanceApi = {
+  // 연차 자동 부여
+  grantAnnualLeave: async (
+    employeeId: number,
+    baseDate?: string
+  ): Promise<EmployeeLeaveBalanceResponseDto[]> => {
+    const params = baseDate ? new URLSearchParams({ baseDate }) : "";
+    const response = await apiClient.post<
+      ApiResult<EmployeeLeaveBalanceResponseDto[]>
+    >(
+      `/api/leave-balance/grant-annual/${employeeId}${
+        params ? `?${params}` : ""
+      }`
+    );
+    return response.data.data;
+  },
+
+  // 특정 타입 잔여 연차 조회
+  getRemainingLeave: async (
+    employeeId: number,
+    leaveType: LeaveType
+  ): Promise<number> => {
+    const params = new URLSearchParams({ leaveType });
+    const response = await apiClient.get<ApiResult<number>>(
+      `/api/leave-balance/remaining/${employeeId}?${params}`
+    );
+    return response.data.data;
+  },
+
+  // 전체 잔여 연차 조회
+  getTotalRemainingLeave: async (employeeId: number): Promise<number> => {
+    const response = await apiClient.get<ApiResult<number>>(
+      `/api/leave-balance/remaining-total/${employeeId}`
+    );
+    return response.data.data;
+  },
+
+  // 연차 잔액 상세 조회
+  getLeaveBalances: async (
+    employeeId: number
+  ): Promise<EmployeeLeaveBalanceResponseDto[]> => {
+    const response = await apiClient.get<
+      ApiResult<EmployeeLeaveBalanceResponseDto[]>
+    >(`/api/leave-balance/details/${employeeId}`);
+    return response.data.data;
+  },
+
+  // 연차 잔액 요약 조회
+  getLeaveBalanceSummary: async (
+    employeeId: number
+  ): Promise<EmployeeLeaveBalanceSummaryDto> => {
+    const response = await apiClient.get<
+      ApiResult<EmployeeLeaveBalanceSummaryDto>
+    >(`/api/leave-balance/summary/${employeeId}`);
+    return response.data.data;
+  },
+
+  // 연차 초기화 및 재부여
+  resetAndGrantAnnualLeave: async (
+    employeeId: number,
+    newGrantDate?: string
+  ): Promise<EmployeeLeaveBalanceResponseDto[]> => {
+    const params = newGrantDate ? new URLSearchParams({ newGrantDate }) : "";
+    const response = await apiClient.post<
+      ApiResult<EmployeeLeaveBalanceResponseDto[]>
+    >(`/api/leave-balance/reset/${employeeId}${params ? `?${params}` : ""}`);
+    return response.data.data;
+  },
+
+  // 연차 복구
+  restoreLeave: async (
+    employeeId: number,
+    leaveType: LeaveType,
+    days: number
+  ): Promise<string> => {
+    const params = new URLSearchParams({
+      leaveType,
+      days: days.toString(),
+    });
+    const response = await apiClient.post<ApiResult<string>>(
+      `/api/leave-balance/restore/${employeeId}?${params}`
+    );
+    return response.data.data;
+  },
+
+  // 전체 직원 연차 초기화
+  resetAllEmployeesAnnualLeave: async (
+    newGrantDate: string
+  ): Promise<string> => {
+    const params = new URLSearchParams({ newGrantDate });
+    const response = await apiClient.post<ApiResult<string>>(
+      `/api/leave-balance/reset-all?${params}`
     );
     return response.data.data;
   },

--- a/lib/services/attendance/index.ts
+++ b/lib/services/attendance/index.ts
@@ -9,6 +9,7 @@ export {
   annualLeaveApi,
   leaveApi,
   workMonitorApi,
+  employeeLeaveBalanceApi,
 } from "./api";
 
 // Export default API object for convenience

--- a/lib/services/attendance/types.ts
+++ b/lib/services/attendance/types.ts
@@ -414,6 +414,34 @@ export interface WeeklyWorkDetail {
   dailySummaries: DailyWorkSummary[];
 }
 
+// 직원 연차 잔액 응답 타입
+export interface EmployeeLeaveBalanceResponseDto {
+  id: number;
+  employeeId: number;
+  leaveType: LeaveType;
+  leaveTypeName: string;
+  totalLeaveDays: number;
+  usedLeaveDays: number;
+  remainingDays: number;
+  workYears: number;
+  usageRate: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// 직원 연차 잔액 요약 타입
+export interface EmployeeLeaveBalanceSummaryDto {
+  employeeId: number;
+  totalRemainingDays: number;
+  totalUsedDays: number;
+  totalGrantedDays: number;
+  leaveBalances: EmployeeLeaveBalanceResponseDto[];
+  basicAnnualRemaining: number;
+  compensationAnnualRemaining: number;
+  specialAnnualRemaining: number;
+  overallUsageRate: number;
+}
+
 // API 응답 래퍼 타입들
 export interface ApiResult<T> {
   status: string;


### PR DESCRIPTION
## 🧩 이슈  번호 
<!-- 이슈 번호를 작성해주세요 -->

- close #112 

## ✅ 작업 사항 

### 연차 정책 UI 추가 및 개선
- “연차 설정” 섹션 추가: 최소/최대 근무년수, 연차/휴일 일수 입력 + 미리보기
- 정책 이름 필드 제거, 그리드 재정렬, 표시 텍스트 정리
- 근무정책 생성 연동
- 생성 페이지에서 annualLeaves 서버 전송 로직 추가
- Attendance 서비스 클라이언트 확장
- 직원 연차 잔액 API 추가
- grantAnnualLeave
- getRemainingLeave
- getTotalRemainingLeave
- getLeaveBalances
- getLeaveBalanceSummary
- resetAndGrantAnnualLeave
- restoreLeave
- resetAllEmployeesAnnualLeave
### 타입 추가
- EmployeeLeaveBalanceResponseDto
- EmployeeLeaveBalanceSummaryDto
### 버그 수정
- TimeWorkForm의 ref 타입 오류 수정 (RefObject에 null 허용)

## 📸 스크린샷 (선택)

## 💬 공유사항

<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
